### PR TITLE
PR for disabling receiver rewards for mainnet

### DIFF
--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div
-	class="sm:navbar sm:py-7 py-[32px] flex sm:justify-normal justify-between md:px-0 px-4 min-h-16 border-b border-black/[0.07]"
+	class="sm:navbar sm:py-7 py-[32px] flex sm:justify-normal justify-between lg:px-0 sm:px-4 px-4 min-h-16 border-b border-black/[0.07]"
 >
 	<div class="sm:navbar-start width-full justify-start items-center flex">
 		<div class="dropdown">

--- a/src/lib/components/header/sub-components/ChainSwitcher.svelte
+++ b/src/lib/components/header/sub-components/ChainSwitcher.svelte
@@ -39,10 +39,13 @@
 
 <svelte:window on:click={(e) => closeSwitcherWhenClickedOutside(e)} />
 
-<details class="dropdown" id="chain-dropdown">
+<details
+	class={$allowedChainsStore.length === 0 ? 'pointer-events-none opacity-60 focus' : 'dropdown'}
+	id="chain-dropdown"
+>
 	<!-- svelte-ignore a11y-no-noninteractive-tabindex -->
 	<summary
-		tabindex="0"
+		tabindex={$allowedChainsStore.length === 0 ? -1 : 0}
 		class="{isDark
 			? buttonClasses.greyFilled
 			: buttonClasses.whiteFilled} border border-sky-500 h-[50px] shadow-sm"

--- a/src/lib/components/prompts/NetworkPrompt.svelte
+++ b/src/lib/components/prompts/NetworkPrompt.svelte
@@ -2,21 +2,18 @@
 	import ContainerCard from '$lib/atoms/cards/ContainerCard.svelte';
 	import Text from '$lib/atoms/texts/Text.svelte';
 	import ChainSwitcher from '$lib/components/header/sub-components/ChainSwitcher.svelte';
-	import PageWrapper from '$lib/components/wrapper/PageWrapper.svelte';
 
 	const styles = {
 		subtitle: 'text-[15px] font-medium text-left mt-1 text-black/50 mt-4 px-2 mb-8 text-center'
 	};
 </script>
 
-<PageWrapper>
-	<ContainerCard>
-		<Text variant="h3" text="Unsupported Network" styleClass="text-center" />
-		<span class={styles.subtitle}
-			>Please switch to one of the chains in the dropdown to continue.</span
-		>
-		<div class="flex items-center justify-center">
-			<ChainSwitcher isDark />
-		</div>
-	</ContainerCard>
-</PageWrapper>
+<ContainerCard>
+	<Text variant="h3" text="Unsupported Network" styleClass="text-center" />
+	<span class={styles.subtitle}
+		>Please switch to one of the chains in the dropdown to continue.</span
+	>
+	<div class="flex items-center justify-center">
+		<ChainSwitcher isDark />
+	</div>
+</ContainerCard>

--- a/src/lib/components/prompts/UnderConstructionPrompt.svelte
+++ b/src/lib/components/prompts/UnderConstructionPrompt.svelte
@@ -1,0 +1,23 @@
+<script>
+	import Button from '$lib/atoms/buttons/Button.svelte';
+	import { DISCORD_LINK } from '$lib/utils/constants/urls';
+	import Text from '$lib/atoms/texts/Text.svelte';
+	import ContainerCard from '$lib/atoms/cards/ContainerCard.svelte';
+
+	const styles = {
+		subtitle: 'text-[15px] font-medium text-left mt-1 text-black/50 mt-4 px-2'
+	};
+</script>
+
+<ContainerCard>
+	<Text variant="h3" text="UH OH!" styleClass="text-center" />
+	<p class={styles.subtitle}>
+		This page is under construction. To get more detials about this page and other exciting stuff
+		that our team is building, check out our
+		<a href={DISCORD_LINK} target="_blank" class="underline text-primary">discord</a>
+		and say "<strong>FISHY</strong>" so we know that you're not a bot.
+	</p>
+	<a class="mt-8 w-full" href="/"
+		><Button styleClass="w-full" variant="filled" size="large">GO BACK HOME</Button></a
+	>
+</ContainerCard>

--- a/src/lib/environments/environment.dev.ts
+++ b/src/lib/environments/environment.dev.ts
@@ -10,7 +10,8 @@ export const ENVIRONMENT_DEV: Environment = {
 	supported_chains: {
 		bridge: [421613],
 		oyster: [421613, 59140],
-		receiver: [421613]
+		receiver_staking: [421613],
+		receiver_rewards: [421613]
 	},
 	dapp_url: 'https://adummy.site',
 	trezor_email: 'arandomsupportemail@xyz.com',

--- a/src/lib/environments/environment.mainnet.ts
+++ b/src/lib/environments/environment.mainnet.ts
@@ -10,7 +10,8 @@ export const ENVIRONMENT_MAINNET: Environment = {
 	supported_chains: {
 		bridge: [42161],
 		oyster: [42161, 59272],
-		receiver: [42161]
+		receiver_staking: [42161],
+		receiver_rewards: []
 	},
 	dapp_url: 'https://arb1.marlin.org',
 	trezor_email: 'security@marlin.org',

--- a/src/lib/page-components/oyster/OysterDashboard.svelte
+++ b/src/lib/page-components/oyster/OysterDashboard.svelte
@@ -26,7 +26,7 @@
 	import {
 		OYSTER_OPERATOR_JOBS_URL,
 		OYSTER_DOC_LINK,
-		OYSTER_SUPPORT_LINK
+		DISCORD_LINK
 	} from '$lib/utils/constants/urls';
 
 	import { getModifiedInstances } from '$lib/utils/data-modifiers/oysterModifiers';
@@ -203,7 +203,7 @@
 					<Text styleClass={styles.docButton} fontWeight="font-medium" text="Documentation" />
 				</a>
 				<div class={dividerClasses.vertical} />
-				<a href={OYSTER_SUPPORT_LINK} target="_blank">
+				<a href={DISCORD_LINK} target="_blank">
 					<Text styleClass={styles.docButton} fontWeight="font-medium" text="Support" />
 				</a>
 			</div>

--- a/src/lib/types/environmentTypes.ts
+++ b/src/lib/types/environmentTypes.ts
@@ -58,4 +58,4 @@ export type SubgraphUrls = {
 	MPOND: string;
 };
 
-type RouteNames = 'bridge' | 'oyster' | 'receiver';
+type RouteNames = 'bridge' | 'oyster' | 'receiver_staking' | 'receiver_rewards';

--- a/src/lib/utils/constants/urls.ts
+++ b/src/lib/utils/constants/urls.ts
@@ -1,6 +1,9 @@
 // _LINK: complete url
 // _URL: internal app routing url
 
+// general links
+export const DISCORD_LINK = 'https://discord.gg/xqJfSGY6gR';
+
 //bridge links
 export const BRIDGE_LEARN_MORE_DOC_LINK = 'https://docs.marlin.org/docs/Learn/Bridges/';
 
@@ -11,7 +14,6 @@ export const MPOND_HISTORY_PAGE_URL = '/bridge/mPondToPondHistory';
 
 //oyster links
 export const OYSTER_DOC_LINK = 'https://docs.marlin.org/docs/User%20Guides/Oyster/';
-export const OYSTER_SUPPORT_LINK = 'https://discord.gg/xqJfSGY6gR';
 
 //oyster pages
 export const OYSTER_MARKETPLACE_URL = '/oyster/marketplace';

--- a/src/routes/bridge/+layout.svelte
+++ b/src/routes/bridge/+layout.svelte
@@ -7,7 +7,7 @@
 		allowedChainsStore
 	} from '$lib/data-stores/chainProviderStore';
 	import { environment } from '$lib/data-stores/environment';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 
 	onMount(() => {
 		setAllowedChainsStore(environment.supported_chains.bridge);
@@ -16,6 +16,10 @@
 	$: chainSupported = $chainStore.chainId
 		? $allowedChainsStore.includes($chainStore.chainId)
 		: true;
+
+	onDestroy(() => {
+		setAllowedChainsStore([]);
+	});
 </script>
 
 <svelte:head>
@@ -27,5 +31,7 @@
 		<slot />
 	</PageWrapper>
 {:else}
-	<NetworkPrompt />
+	<PageWrapper>
+		<NetworkPrompt />
+	</PageWrapper>
 {/if}

--- a/src/routes/oyster/+layout.svelte
+++ b/src/routes/oyster/+layout.svelte
@@ -32,7 +32,7 @@
 	} from '$lib/utils/data-modifiers/oysterModifiers';
 	import { addRegionNameToMarketplaceData } from '$lib/utils/helpers/oysterHelpers';
 	import type { BrowserProvider } from 'ethers';
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 
 	onMount(() => {
 		setAllowedChainsStore(environment.supported_chains.oyster);
@@ -97,6 +97,10 @@
 	$: if ($connected && $chainStore.chainId && chainSupported) {
 		loadConnectedData();
 	}
+
+	onDestroy(() => {
+		setAllowedChainsStore([]);
+	});
 </script>
 
 <svelte:head>
@@ -108,5 +112,7 @@
 		<slot />
 	</PageWrapper>
 {:else}
-	<NetworkPrompt />
+	<PageWrapper>
+		<NetworkPrompt />
+	</PageWrapper>
 {/if}

--- a/src/routes/relay/+layout.svelte
+++ b/src/routes/relay/+layout.svelte
@@ -1,27 +1,7 @@
 <script lang="ts">
-	import NetworkPrompt from '$lib/components/prompts/NetworkPrompt.svelte';
 	import PageWrapper from '$lib/components/wrapper/PageWrapper.svelte';
-	import {
-		allowedChainsStore,
-		chainStore,
-		setAllowedChainsStore
-	} from '$lib/data-stores/chainProviderStore';
-	import { environment } from '$lib/data-stores/environment';
-	import { onMount } from 'svelte';
-
-	onMount(() => {
-		setAllowedChainsStore(environment.supported_chains.receiver);
-	});
-
-	$: chainSupported = $chainStore.chainId
-		? $allowedChainsStore.includes($chainStore.chainId)
-		: true;
 </script>
 
-{#if $chainStore.isValidChain && chainSupported}
-	<PageWrapper>
-		<slot />
-	</PageWrapper>
-{:else}
-	<NetworkPrompt />
-{/if}
+<PageWrapper>
+	<slot />
+</PageWrapper>

--- a/src/routes/relay/receiver/rewards/+page.svelte
+++ b/src/routes/relay/receiver/rewards/+page.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
+	import NetworkPrompt from '$lib/components/prompts/NetworkPrompt.svelte';
+	import UnderConstructionPrompt from '$lib/components/prompts/UnderConstructionPrompt.svelte';
 	import { getReceiverRewardsDataFromSubgraph } from '$lib/controllers/subgraphController';
-	import { chainStore } from '$lib/data-stores/chainProviderStore';
+	import {
+		allowedChainsStore,
+		chainStore,
+		setAllowedChainsStore
+	} from '$lib/data-stores/chainProviderStore';
+	import { environment } from '$lib/data-stores/environment';
 	import { receiverRewardsStore } from '$lib/data-stores/receiverRewardsStore';
 	import { connected, walletStore } from '$lib/data-stores/walletProviderStore';
 	import RewardsDashboard from '$lib/page-components/receiver-rewards/RewardsDashboard.svelte';
 	import { modifyReceiverRewardsData } from '$lib/utils/data-modifiers/subgraphModifier';
+	import { onDestroy, onMount } from 'svelte';
+
+	onMount(() => {
+		setAllowedChainsStore(environment.supported_chains.receiver_rewards);
+	});
 
 	async function loadConnectedData() {
 		try {
@@ -19,9 +31,23 @@
 		console.log('receiver reward store is updated with data');
 	}
 
-	$: if ($connected && $chainStore.chainId) {
+	$: chainSupported = $chainStore.chainId
+		? $allowedChainsStore.includes($chainStore.chainId)
+		: true;
+
+	$: if ($connected && $chainStore.chainId && chainSupported) {
 		loadConnectedData();
 	}
+
+	onDestroy(() => {
+		setAllowedChainsStore([]);
+	});
 </script>
 
-<RewardsDashboard />
+{#if chainSupported}
+	<RewardsDashboard />
+{:else if !chainSupported && $allowedChainsStore.length > 0}
+	<NetworkPrompt />
+{:else if !chainSupported && $allowedChainsStore.length === 0}
+	<UnderConstructionPrompt />
+{/if}

--- a/src/routes/relay/receiver/staking/+page.svelte
+++ b/src/routes/relay/receiver/staking/+page.svelte
@@ -1,10 +1,21 @@
 <script lang="ts">
+	import NetworkPrompt from '$lib/components/prompts/NetworkPrompt.svelte';
 	import { getReceiverStakingDataFromSubgraph } from '$lib/controllers/subgraphController';
-	import { chainStore } from '$lib/data-stores/chainProviderStore';
+	import {
+		allowedChainsStore,
+		chainStore,
+		setAllowedChainsStore
+	} from '$lib/data-stores/chainProviderStore';
+	import { environment } from '$lib/data-stores/environment';
 	import { initializeReceiverStakingStore } from '$lib/data-stores/receiverStakingStore';
 	import { walletStore } from '$lib/data-stores/walletProviderStore';
 	import StakeDashboard from '$lib/page-components/receiver-staking/StakeDashboard.svelte';
 	import { modifyReceiverStakingData } from '$lib/utils/data-modifiers/subgraphModifier';
+	import { onDestroy, onMount } from 'svelte';
+
+	onMount(() => {
+		setAllowedChainsStore(environment.supported_chains.receiver_staking);
+	});
 
 	let prevWalletAddress: string | null = null;
 	let prevChainId: number | null = null;
@@ -31,10 +42,22 @@
 		prevWalletAddress = null;
 		prevChainId = null;
 	}
+
+	$: chainSupported = $chainStore.chainId
+		? $allowedChainsStore.includes($chainStore.chainId)
+		: true;
+
+	onDestroy(() => {
+		setAllowedChainsStore([]);
+	});
 </script>
 
 <svelte:head>
 	<title>Marlin Receiver Portal</title>
 </svelte:head>
 
-<StakeDashboard />
+{#if chainSupported}
+	<StakeDashboard />
+{:else}
+	<NetworkPrompt />
+{/if}


### PR DESCRIPTION
- created a new prompt component which says "Page is under construction" with a link to our discord.
- refactored `chainSwitcher.svelte` to be in a disabled state when there are no allowed chains for a route
- renamed `OYSTER_SUPPORT_LINK` -> `DISCORD_LINK` for better readability and reusability
- Since each page is independent in `relay/receivers` and supports different chains the layout route cannot check if the chain is supported or not, this is now being decided at a page level (for `relay/receivers` only)