### PR TITLE
PR to refactor the explicit subscriptions to $ notation

### DIFF
--- a/src/lib/components/header/sub-components/ConnectWalletButton.svelte
+++ b/src/lib/components/header/sub-components/ConnectWalletButton.svelte
@@ -10,12 +10,13 @@
 	export let isLarge = false;
 	export let connectButtonText = 'Connect Wallet';
 
+	const connectWalletStyles = 'flex gap-[10.3px] ';
+
 	const connect = async () => {
 		console.log('connecting to the wallet...');
 		const connection = await onboard.connectWallet();
 		console.log('connection', connection);
 	};
-	const connectWalletStyles = 'flex gap-[10.3px] ';
 
 	$: connectedAccount = $web3WalletStore?.[0];
 	$: if (connectedAccount) {

--- a/src/lib/components/inputs/InputCardWithEndButton.svelte
+++ b/src/lib/components/inputs/InputCardWithEndButton.svelte
@@ -11,6 +11,7 @@
 		rowWrapper: 'flex items-center justify-between',
 		titleIcon: 'flex items-center gap-1'
 	};
+
 	let innerWidth = 0;
 </script>
 

--- a/src/lib/components/inputs/TextInputWithEndButton.svelte
+++ b/src/lib/components/inputs/TextInputWithEndButton.svelte
@@ -7,7 +7,6 @@
 	export let title: string;
 	export let placeholder = '';
 	export let disabled = false;
-
 	export let input: string;
 
 	const styles = {

--- a/src/lib/components/modals/ApproveAndConfirmModal.svelte
+++ b/src/lib/components/modals/ApproveAndConfirmModal.svelte
@@ -6,7 +6,6 @@
 	import { DEFAULT_CURRENCY_DECIMALS } from '$lib/utils/constants/constants';
 	import { bigNumberToString, mPondToPond, pondToMPond } from '$lib/utils/helpers/conversionHelper';
 	import { closeModal, openModal } from '$lib/utils/helpers/commonHelper';
-
 	import { staticImages } from '$lib/components/images/staticImages';
 	import LoadingAnimationModal from '$lib/components/loading/LoadingAnimationModal.svelte';
 	import { getAmountPrecision } from '$lib/utils/helpers/bridgeHelpers';
@@ -20,22 +19,15 @@
 	export let confirmButtonText = 'CONFIRM';
 	export let amountConverted = 0n;
 	export let conversionFrom: 'pond' | 'mPond' = 'pond';
-
 	export let modalForApproveConfirm: string;
 
-	$: amountConvertedFrom = bigNumberToString(
-		amountConverted,
-		DEFAULT_CURRENCY_DECIMALS,
-		getAmountPrecision(conversionFrom)
-	);
-	$: amountConvertedTo = bigNumberToString(
-		conversionFrom === 'pond' ? pondToMPond(amountConverted) : mPondToPond(amountConverted),
-		DEFAULT_CURRENCY_DECIMALS,
-		getAmountPrecision(conversionFrom === 'pond' ? 'mPond' : 'pond')
-	);
-	$: conversionFromText = conversionFrom === 'pond' ? 'POND' : 'MPond';
-	$: conversionToText = conversionFrom === 'pond' ? 'MPond' : 'POND';
-	$: modalForSuccessConversion = `success-conversion-modal-${rowIndex}`;
+	const styles = {
+		baseText: 'grow text-left  font-normal',
+		text: 'text-grey-500 font-[15px]',
+		textBold: 'font-semibold text-black',
+		textDisabled: 'font-semibold text-grey-300'
+	};
+
 	let approveLoading: boolean;
 	let confirmLoading: boolean;
 
@@ -66,12 +58,19 @@
 	};
 	// const modalWidth = 'max-w-[500px]';
 
-	const styles = {
-		baseText: 'grow text-left  font-normal',
-		text: 'text-grey-500 font-[15px]',
-		textBold: 'font-semibold text-black',
-		textDisabled: 'font-semibold text-grey-300'
-	};
+	$: amountConvertedFrom = bigNumberToString(
+		amountConverted,
+		DEFAULT_CURRENCY_DECIMALS,
+		getAmountPrecision(conversionFrom)
+	);
+	$: amountConvertedTo = bigNumberToString(
+		conversionFrom === 'pond' ? pondToMPond(amountConverted) : mPondToPond(amountConverted),
+		DEFAULT_CURRENCY_DECIMALS,
+		getAmountPrecision(conversionFrom === 'pond' ? 'mPond' : 'pond')
+	);
+	$: conversionFromText = conversionFrom === 'pond' ? 'POND' : 'MPond';
+	$: conversionToText = conversionFrom === 'pond' ? 'MPond' : 'POND';
+	$: modalForSuccessConversion = `success-conversion-modal-${rowIndex}`;
 </script>
 
 <Modal modalFor={modalForApproveConfirm}>

--- a/src/lib/components/prompts/SmallScreenPrompt.svelte
+++ b/src/lib/components/prompts/SmallScreenPrompt.svelte
@@ -2,6 +2,7 @@
 	import Button from '$lib/atoms/buttons/Button.svelte';
 
 	export let showSmallScreenPrompt = false;
+
 	let innerWidth: number;
 
 	$: if (innerWidth < 950) {

--- a/src/lib/components/search/SearchWithSelect.svelte
+++ b/src/lib/components/search/SearchWithSelect.svelte
@@ -9,7 +9,6 @@
 	export let searchValue: string | number | undefined = '';
 	export let setSearchValue: (value: string | number, exactMatch?: boolean) => any;
 	export let onSearchClick: (() => void) | undefined = undefined;
-
 	export let title: string;
 	export let showTitle = true;
 	export let onlyFilters = false;
@@ -20,10 +19,17 @@
 	export let isTableFilter = false;
 	export let textSuffix = '';
 
+	const styles = {
+		rowWrapper: 'flex items-center justify-between',
+		titleIcon: 'flex items-center gap-1',
+		inputSearchBold: inputClasses.inputText,
+		inputSearch: inputClasses.searchInputText
+	};
+
 	let suggestions: (string | number)[] = [];
 	let showSuggestions = false;
 
-	const handleSearch = async (event: any) => {
+	const handleSearch = async (event: Event) => {
 		const input = event.target as HTMLInputElement;
 		searchValue = input.value;
 		// close suggestions if search is empty
@@ -41,13 +47,6 @@
 		);
 		showSuggestions = suggestions.length > 0;
 		await setSearchValue(searchValue, false);
-	};
-
-	const styles = {
-		rowWrapper: 'flex items-center justify-between',
-		titleIcon: 'flex items-center gap-1',
-		inputSearchBold: inputClasses.inputText,
-		inputSearch: inputClasses.searchInputText
 	};
 </script>
 

--- a/src/lib/components/status/StatusCircle.svelte
+++ b/src/lib/components/status/StatusCircle.svelte
@@ -5,8 +5,7 @@
 	export let variant: CommonVariant = 'primary';
 	export let styleClass = '';
 
-	const color = getColorHexByVariant(variant);
 	$: style = `${styleClass} w-5 h-5 rounded-full mx-auto`;
 </script>
 
-<div class={style} style={`background-color:${color}`} />
+<div class={style} style={`background-color:${getColorHexByVariant(variant)}`} />

--- a/src/lib/page-components/bridge/BridgeDashboard.svelte
+++ b/src/lib/page-components/bridge/BridgeDashboard.svelte
@@ -13,10 +13,12 @@
 	import ConversionHistoryButton from '$lib/page-components/bridge/sub-components/ConversionHistoryButton.svelte';
 	import TabPondMPond from '$lib/page-components/bridge/sub-components/TabPondMPond.svelte';
 
+	let activeTabValue = 'pond';
+
 	const styles = {
 		conversionHistory: 'flex flex-col w-full sm:w-130 mx-auto mt-4'
 	};
-	$: activeTabValue = 'pond';
+
 	const handleClick = (tabValue: string) => () => {
 		activeTabValue = tabValue;
 	};

--- a/src/lib/page-components/bridge/PondApproveConfirmModal.svelte
+++ b/src/lib/page-components/bridge/PondApproveConfirmModal.svelte
@@ -11,8 +11,6 @@
 	} from '$lib/data-stores/walletProviderStore';
 	import { pondToMPond } from '$lib/utils/helpers/conversionHelper';
 	import { doNothing } from '$lib/utils/helpers/commonHelper';
-
-	import { onDestroy } from 'svelte';
 	import { contractAddressStore } from '$lib/data-stores/contractStore';
 	import { chainConfigStore } from '$lib/data-stores/chainProviderStore';
 	import { convertPondToMPond } from '$lib/controllers/contract/bridge';
@@ -22,10 +20,6 @@
 	export let modalFor: string;
 
 	let approved = false;
-	const unsubscribeBridgeStore = bridgeStore.subscribe((value) => {
-		const amount = value.allowances.pond;
-		approved = amount >= pond || false;
-	});
 
 	const handleApproveClick = async () => {
 		try {
@@ -56,7 +50,6 @@
 
 	$: mPond = pondToMPond(pond);
 	$: approved = $bridgeStore.allowances.pond >= pond || false;
-	onDestroy(unsubscribeBridgeStore);
 </script>
 
 <ApproveAndConfirmModal

--- a/src/lib/page-components/bridge/buttons/MPondConversionHistoryButton.svelte
+++ b/src/lib/page-components/bridge/buttons/MPondConversionHistoryButton.svelte
@@ -6,7 +6,6 @@
 	import HistoryDataIconButton from '$lib/page-components/bridge/sub-components/HistoryDataIconButton.svelte';
 
 	export let conversionHistory: MPondToPondHistoryDataModel['conversionHistory'];
-
 	export let modalFor: string;
 </script>
 

--- a/src/lib/page-components/bridge/history/MPondTableRow.svelte
+++ b/src/lib/page-components/bridge/history/MPondTableRow.svelte
@@ -33,6 +33,9 @@
 	export let rowData: MPondToPondHistoryDataModel;
 	export let rowIndex: number;
 
+	const cancelTooltipText =
+		'Cancel current MPond conversion requests in process. Users who want the updated MPond conversion parameters to take immediate effect may cancel the current conversion request and place a new conversion request.';
+
 	const getTimerEpoch = (
 		currentCycle: number,
 		eligibleCycles: MPondEligibleCyclesModel[] | undefined
@@ -41,26 +44,6 @@
 		return eligibleCycles[currentCycle].endTimestamp;
 	};
 
-	$: ({
-		timestamp,
-		transactionHash,
-		mpondAmount,
-		pondAmount,
-		pondPending,
-		eligibleCycles,
-		currentCycle,
-		pondInProcess,
-		pondEligible,
-		conversionHistory,
-		requestEpoch,
-		mpondConverted
-	} = rowData);
-
-	$: cancelDisabled =
-		(!pondEligible || pondEligible === 0n) &&
-		(!pondPending || pondPending === 0n) &&
-		(!pondInProcess || pondInProcess === 0n);
-	$: endEpochTime = getTimerEpoch(currentCycle, eligibleCycles);
 	const handleCancelConversionRequest = async (requestEpoch: bigint) => {
 		//not working yet
 		await cancelMPondConversionRequest(requestEpoch);
@@ -94,8 +77,26 @@
 		};
 	};
 
-	const cancelTooltipText =
-		'Cancel current MPond conversion requests in process. Users who want the updated MPond conversion parameters to take immediate effect may cancel the current conversion request and place a new conversion request.';
+	$: ({
+		timestamp,
+		transactionHash,
+		mpondAmount,
+		pondAmount,
+		pondPending,
+		eligibleCycles,
+		currentCycle,
+		pondInProcess,
+		pondEligible,
+		conversionHistory,
+		requestEpoch,
+		mpondConverted
+	} = rowData);
+
+	$: cancelDisabled =
+		(!pondEligible || pondEligible === 0n) &&
+		(!pondPending || pondPending === 0n) &&
+		(!pondInProcess || pondInProcess === 0n);
+	$: endEpochTime = getTimerEpoch(currentCycle, eligibleCycles);
 </script>
 
 <tr>

--- a/src/lib/page-components/bridge/history/MPondToPondHistoryData.svelte
+++ b/src/lib/page-components/bridge/history/MPondToPondHistoryData.svelte
@@ -2,33 +2,31 @@
 	import { getMPondToPondConversionHistoryFromSubgraph } from '$lib/controllers/subgraphController';
 	import { walletStore } from '$lib/data-stores/walletProviderStore';
 	import type { MPondToPondHistoryDataModel } from '$lib/types/bridgeComponentType';
-	import type { Address, WalletStore } from '$lib/types/storeTypes';
+	import type { Address } from '$lib/types/storeTypes';
 	import { MPOND_TO_POND_TABLE_HEADER } from '$lib/utils/constants/bridgeConstants';
-	import { onDestroy } from 'svelte';
-	import type { Unsubscriber } from 'svelte/store';
 	import HistoryTableCommon from '$lib/page-components/bridge/history/HistoryTableCommon.svelte';
 	import MPondTableRow from '$lib/page-components/bridge/history/MPondTableRow.svelte';
 	import { POND_HISTORY_PAGE_URL } from '$lib/utils/constants/urls';
 	import { modifyMPondToPondConversionHistory } from '$lib/utils/data-modifiers/subgraphModifier';
 
-	let address: Address;
 	let historyData: MPondToPondHistoryDataModel[] | undefined;
 	let loading = true;
-	const unsubscribeWalletStore: Unsubscriber = walletStore.subscribe(async (value: WalletStore) => {
-		address = value.address;
-		if (address) {
-			loading = true;
-			const historyDataFromSubgraph = await getMPondToPondConversionHistoryFromSubgraph(address);
-			historyData = modifyMPondToPondConversionHistory(historyDataFromSubgraph);
-			loading = false;
-		}
-	});
-	onDestroy(unsubscribeWalletStore);
 
 	// reverse the order of sortedData
 	const handleSortData = (id: string) => {
 		historyData = historyData?.reverse();
 	};
+
+	async function getHistoryData(address: Address) {
+		loading = true;
+		const historyDataFromSubgraph = await getMPondToPondConversionHistoryFromSubgraph(address);
+		historyData = modifyMPondToPondConversionHistory(historyDataFromSubgraph);
+		loading = false;
+	}
+
+	$: if ($walletStore.address) {
+		getHistoryData($walletStore.address);
+	}
 </script>
 
 <HistoryTableCommon

--- a/src/lib/page-components/bridge/history/PondToMPondHistoryData.svelte
+++ b/src/lib/page-components/bridge/history/PondToMPondHistoryData.svelte
@@ -4,7 +4,7 @@
 	import { getPondToMPondConversionHistoryFromSubgraph } from '$lib/controllers/subgraphController';
 	import { walletStore } from '$lib/data-stores/walletProviderStore';
 	import type { PondToMPondHistoryDataModel } from '$lib/types/bridgeComponentType';
-	import type { Address, WalletStore } from '$lib/types/storeTypes';
+	import type { Address } from '$lib/types/storeTypes';
 	import { POND_TO_MPOND_TABLE_HEADER } from '$lib/utils/constants/bridgeConstants';
 	import {
 		DEFAULT_CURRENCY_DECIMALS,
@@ -12,32 +12,30 @@
 		POND_PRECISIONS
 	} from '$lib/utils/constants/constants';
 	import { bigNumberToString, epochSecToString } from '$lib/utils/helpers/conversionHelper';
-	import { onDestroy } from 'svelte';
-	import type { Unsubscriber } from 'svelte/store';
 	import HistoryTableCommon from '$lib/page-components/bridge/history/HistoryTableCommon.svelte';
 	import { MPOND_HISTORY_PAGE_URL } from '$lib/utils/constants/urls';
 	import { modifyPondToMpondConversionHistory } from '$lib/utils/data-modifiers/subgraphModifier';
 	import { getTxnUrl } from '$lib/utils/helpers/commonHelper';
 	import { chainConfigStore } from '$lib/data-stores/chainProviderStore';
 
-	let address: Address;
 	let historyData: PondToMPondHistoryDataModel[] | undefined;
 	let loading = true;
-	const unsubscribeWalletStore: Unsubscriber = walletStore.subscribe(async (value: WalletStore) => {
-		address = value.address;
-		if (address) {
-			loading = true;
-			const historyDataFromSubgraph = await getPondToMPondConversionHistoryFromSubgraph(address);
-			historyData = modifyPondToMpondConversionHistory(historyDataFromSubgraph);
-			loading = false;
-		}
-	});
-	onDestroy(unsubscribeWalletStore);
 
 	// reverse the order of sortedData
 	const handleSortData = (id: string) => {
 		historyData = historyData?.reverse();
 	};
+
+	async function getHistoryData(address: Address) {
+		loading = true;
+		const historyDataFromSubgraph = await getPondToMPondConversionHistoryFromSubgraph(address);
+		historyData = modifyPondToMpondConversionHistory(historyDataFromSubgraph);
+		loading = false;
+	}
+
+	$: if ($walletStore.address) {
+		getHistoryData($walletStore.address);
+	}
 </script>
 
 <HistoryTableCommon

--- a/src/lib/page-components/bridge/modals/MPondApproveConfirmModal.svelte
+++ b/src/lib/page-components/bridge/modals/MPondApproveConfirmModal.svelte
@@ -11,8 +11,6 @@
 	} from '$lib/data-stores/walletProviderStore';
 	import { mPondToPond } from '$lib/utils/helpers/conversionHelper';
 	import { closeModal } from '$lib/utils/helpers/commonHelper';
-
-	import { onDestroy } from 'svelte';
 	import { contractAddressStore } from '$lib/data-stores/contractStore';
 	import { chainConfigStore } from '$lib/data-stores/chainProviderStore';
 	import { confirmMPondConversion } from '$lib/controllers/contract/bridge';
@@ -25,12 +23,8 @@
 	export let modalToClose: string;
 	export let handleOnSuccess: (txnHash: string) => void;
 
-	let amount = 0n;
 	let approved = false;
-	const unsubscribeBridgeStore = bridgeStore.subscribe((value) => {
-		amount = value.allowances.mPond;
-	});
-	onDestroy(unsubscribeBridgeStore);
+	let txnHash = '';
 
 	const handleApproveClick = async () => {
 		try {
@@ -50,7 +44,6 @@
 		}
 	};
 
-	let txnHash = '';
 	const handleConfirmClick = async () => {
 		try {
 			const txn = await confirmMPondConversion(requestEpoch, mpondToConvert);
@@ -66,7 +59,8 @@
 			throw error;
 		}
 	};
-	$: approved = amount >= mpondToConvert || false;
+
+	$: approved = $bridgeStore.allowances.mPond >= mpondToConvert || false;
 </script>
 
 <ApproveAndConfirmModal

--- a/src/lib/page-components/bridge/modals/MPondConversionHistoryModal.svelte
+++ b/src/lib/page-components/bridge/modals/MPondConversionHistoryModal.svelte
@@ -13,9 +13,8 @@
 		mPondToPond
 	} from '$lib/utils/helpers/conversionHelper';
 
-	export let conversions: MPondToPondHistoryDataModel['conversionHistory'];
-
 	export let modalFor: string;
+	export let conversions: MPondToPondHistoryDataModel['conversionHistory'];
 </script>
 
 <Modal {modalFor} isScrollable>

--- a/src/lib/page-components/bridge/modals/MPondEligibleConvertModal.svelte
+++ b/src/lib/page-components/bridge/modals/MPondEligibleConvertModal.svelte
@@ -12,7 +12,6 @@
 		inputAmountInValidMessage,
 		isInputAmountValid
 	} from '$lib/utils/helpers/commonHelper';
-
 	import MPondApproveConfirmModal from '$lib/page-components/bridge/modals/MPondApproveConfirmModal.svelte';
 
 	export let modalFor: string;
@@ -21,21 +20,10 @@
 	export let rowIndex: number;
 	export let handleOnSuccess: (convertedMPond: bigint, txnHash: string) => void;
 
-	$: balanceText = `Eligible Balance: ${bigNumberToString(
-		maxAmount,
-		DEFAULT_CURRENCY_DECIMALS,
-		MPOND_PRECISIONS
-	)}`;
-
 	//initial amount states
 	let inputAmount: bigint;
 	let inputAmountString: string;
 	let modalForMPondApproveConfirm = 'mpond-approve-confirm-modal';
-
-	$: inputAmount = isInputAmountValid(inputAmountString)
-		? stringToBigNumber(inputAmountString)
-		: 0n;
-
 	//input amount states
 	let inputAmountIsValid = true;
 	let updatedAmountInputDirty = false;
@@ -48,10 +36,6 @@
 		inputAmountIsValid = target.value ? isInputAmountValid(target.value) : true;
 		inValidMessage = inputAmountInValidMessage(target.value);
 	};
-
-	$: mPondDisabledText = inputAmount && inputAmount > maxAmount ? 'Insufficient balance' : '';
-	$: submitEnable = inputAmount && inputAmount > 0 && maxAmount >= inputAmount;
-	$: modalIdWithRowIndex = `${modalForMPondApproveConfirm}-${rowIndex}`;
 
 	const handleMaxClick = () => {
 		if (maxAmount) {
@@ -76,6 +60,18 @@
 		closeModal(modalFor);
 		closeModal(modalIdWithRowIndex);
 	};
+
+	$: balanceText = `Eligible Balance: ${bigNumberToString(
+		maxAmount,
+		DEFAULT_CURRENCY_DECIMALS,
+		MPOND_PRECISIONS
+	)}`;
+	$: inputAmount = isInputAmountValid(inputAmountString)
+		? stringToBigNumber(inputAmountString)
+		: 0n;
+	$: mPondDisabledText = inputAmount && inputAmount > maxAmount ? 'Insufficient balance' : '';
+	$: submitEnable = inputAmount && inputAmount > 0 && maxAmount >= inputAmount;
+	$: modalIdWithRowIndex = `${modalForMPondApproveConfirm}-${rowIndex}`;
 </script>
 
 <Modal {modalFor} onClose={resetInputs}>

--- a/src/lib/page-components/oyster/OysterDashboard.svelte
+++ b/src/lib/page-components/oyster/OysterDashboard.svelte
@@ -20,7 +20,6 @@
 	import { addToast } from '$lib/data-stores/toastStore';
 	import { connected, walletStore } from '$lib/data-stores/walletProviderStore';
 	import { checkValidURL } from '$lib/utils/helpers/commonHelper';
-	import { onDestroy } from 'svelte';
 	import edit from 'svelte-awesome/icons/edit';
 	import InstancesTable from '$lib/page-components/oyster/sub-components/InstancesTable.svelte';
 	import {
@@ -41,36 +40,16 @@
 		tableCell: tableCellClasses.rowMini
 	};
 
-	let displayAddress = '';
 	let enableRegisterButton = false;
-
 	let updatedCpURL = '';
 	let registeredCpURL = '';
 	let registered = false;
 	let disableCpURL = true;
+	let openInstanceTable = false;
+	// loading states
 	let unregisterLoading = false;
 	let registerLoading = false;
 	let updateLoading = false;
-
-	let openInstanceTable = false;
-
-	const unsubscribeWalletStore = walletStore.subscribe((value) => {
-		displayAddress = value.address;
-	});
-	onDestroy(unsubscribeWalletStore);
-
-	const unsubscribeOysterStore = oysterStore.subscribe((value) => {
-		if (value.providerData.data) {
-			registeredCpURL = value.providerData.data.cp;
-			updatedCpURL = value.providerData.data.cp;
-			registered = value.providerData.registered ?? false;
-		} else {
-			registeredCpURL = '';
-			updatedCpURL = '';
-			registered = false;
-		}
-	});
-	onDestroy(unsubscribeOysterStore);
 
 	const handleOnRegister = async () => {
 		if (connected) {
@@ -157,6 +136,9 @@
 	// Define the debounced version of getInstances
 	const debouncedGetInstances = debounce(getInstances, 4000);
 
+	$: registeredCpURL = $oysterStore.providerData.data?.cp ?? '';
+	$: updatedCpURL = $oysterStore.providerData.data?.cp ?? '';
+	$: registered = $oysterStore.providerData.registered ?? false;
 	$: if (updatedCpURL !== registeredCpURL) {
 		enableRegisterButton = false;
 	}
@@ -213,7 +195,7 @@
 		title={'Address'}
 		tooltipText={'Address of oyster operator'}
 		placeholder={'Enter your address here'}
-		bind:input={displayAddress}
+		bind:input={$walletStore.address}
 		disabled={true}
 	/>
 	<TextInputWithEndButton

--- a/src/lib/page-components/oyster/history/OysterHistoryPage.svelte
+++ b/src/lib/page-components/oyster/history/OysterHistoryPage.svelte
@@ -7,8 +7,6 @@
 	import type { OysterInventoryDataModel } from '$lib/types/oysterComponentType';
 	import { OYSTER_HISTORY_TABLE_HEADER } from '$lib/utils/constants/oysterConstants';
 	import { getSearchedInventoryData, sortOysterInventory } from '$lib/utils/helpers/oysterHelpers';
-	import { onDestroy } from 'svelte';
-	import type { Unsubscriber } from 'svelte/store';
 	import OysterTableCommon from '$lib/page-components/oyster/inventory/OysterTableCommon.svelte';
 	import OysterHistoryTableRow from '$lib/page-components/oyster/history/OysterHistoryTableRow.svelte';
 	import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
@@ -16,16 +14,7 @@
 	let searchInput = '';
 	let activePage = 1;
 	let sortingMap: Record<string, 'asc' | 'desc'> = {};
-
-	const itemsPerPage = TABLE_ITEMS_PER_PAGE;
-
 	let inventoryData: OysterInventoryDataModel[] | undefined;
-
-	const unsubscribeOysterStore: Unsubscriber = oysterStore.subscribe(async (value) => {
-		inventoryData = value.jobsData;
-		inventoryData = inventoryData?.filter((data) => !data.live);
-	});
-	onDestroy(unsubscribeOysterStore);
 
 	const handleSortData = (id: string) => {
 		if (sortingMap[id]) {
@@ -48,16 +37,16 @@
 		activePage = 1;
 	};
 
+	// fiter inventory data based on live status
+	$: inventoryData = $oysterStore.jobsData?.filter((data) => !data.live);
 	// get searched data based on searchInput
 	$: searchedData = getSearchedInventoryData(searchInput, inventoryData);
-
 	// get page array based on inventory and itemsPerPage
-	$: pageCount = Math.ceil((searchedData?.length ?? 0) / itemsPerPage);
-
+	$: pageCount = Math.ceil((searchedData?.length ?? 0) / TABLE_ITEMS_PER_PAGE);
 	// get paginated data based on activePage
 	$: paginatedData = searchedData?.slice(
-		(activePage - 1) * itemsPerPage,
-		activePage * itemsPerPage
+		(activePage - 1) * TABLE_ITEMS_PER_PAGE,
+		activePage * TABLE_ITEMS_PER_PAGE
 	);
 </script>
 

--- a/src/lib/page-components/oyster/history/OysterHistoryTableRow.svelte
+++ b/src/lib/page-components/oyster/history/OysterHistoryTableRow.svelte
@@ -28,7 +28,6 @@
 		createdAt,
 		endEpochTime
 	} = rowData);
-
 	$: statusColor = getColorHexByVariant(getInventoryStatusVariant(status) as CommonVariant);
 </script>
 

--- a/src/lib/page-components/oyster/inventory/OysterInventoryPage.svelte
+++ b/src/lib/page-components/oyster/inventory/OysterInventoryPage.svelte
@@ -10,29 +10,17 @@
 	import type { OysterInventoryDataModel } from '$lib/types/oysterComponentType';
 	import { OYSTER_INVENTORY_TABLE_HEADER } from '$lib/utils/constants/oysterConstants';
 	import { getSearchedInventoryData, sortOysterInventory } from '$lib/utils/helpers/oysterHelpers';
-	import { onDestroy } from 'svelte';
 	import plus from 'svelte-awesome/icons/plus';
-	import type { Unsubscriber } from 'svelte/store';
 	import OysterTableCommon from '$lib/page-components/oyster/inventory/OysterTableCommon.svelte';
 	import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
 
 	let searchInput = '';
 	let activePage = 1;
 	let sortingMap: Record<string, 'asc' | 'desc'> = {};
-
-	const itemsPerPage = TABLE_ITEMS_PER_PAGE;
-
-	let loading = true;
 	let inventoryData: OysterInventoryDataModel[] | undefined;
 
 	// Defining a Set to store the indices of the expanded rows
 	let expandedRows = new Set<string>();
-
-	const unsubscribeOysterStore: Unsubscriber = oysterStore.subscribe(async (value) => {
-		inventoryData = value.jobsData;
-		loading = !value.oysterStoreLoaded;
-	});
-	onDestroy(unsubscribeOysterStore);
 
 	const handleSortData = (id: string) => {
 		if (sortingMap[id]) {
@@ -56,15 +44,13 @@
 	};
 
 	// get searched data based on searchInput
-	$: searchedData = getSearchedInventoryData(searchInput, inventoryData);
-
+	$: searchedData = getSearchedInventoryData(searchInput, $oysterStore.jobsData);
 	// get page array based on inventory and itemsPerPage
-	$: pageCount = Math.ceil((searchedData?.length ?? 0) / itemsPerPage);
-
+	$: pageCount = Math.ceil((searchedData?.length ?? 0) / TABLE_ITEMS_PER_PAGE);
 	// get paginated data based on activePage
 	$: paginatedData = searchedData?.slice(
-		(activePage - 1) * itemsPerPage,
-		activePage * itemsPerPage
+		(activePage - 1) * TABLE_ITEMS_PER_PAGE,
+		activePage * TABLE_ITEMS_PER_PAGE
 	);
 </script>
 
@@ -88,7 +74,7 @@
 	<OysterTableCommon
 		{handleSortData}
 		tableHeading={OYSTER_INVENTORY_TABLE_HEADER}
-		{loading}
+		loading={!$oysterStore.oysterStoreLoaded}
 		noDataFound={paginatedData?.length ? false : true}
 		emptyTableMessage={'You do not have any active orders.'}
 	>

--- a/src/lib/page-components/oyster/inventory/modals/AddFundsToJobModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/AddFundsToJobModal.svelte
@@ -27,7 +27,6 @@
 	let instanceCostScaled = 0n;
 	let invalidCost = false;
 	let durationUnitInSec: number;
-
 	//loading states
 	let submitLoading = false;
 	let approvedLoading = false;

--- a/src/lib/page-components/oyster/inventory/modals/AmendRateModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/AmendRateModal.svelte
@@ -24,14 +24,13 @@
 	export let modalFor: string;
 	export let jobData: OysterInventoryDataModel;
 
-	$: ({ rate, reviseRate: { newRate = 0n, updatesAt = 0, rateStatus = '' } = {} } = jobData);
-
-	//initial states
+	// initial states
 	let inputRate = 0n;
 	let inputAmountString = '';
-
+	// loading states
 	let submitLoading = false;
 	let cancelLoading = false;
+	// error state
 	let showPrecisionError = false;
 
 	const handleInitiateClick = async () => {
@@ -67,6 +66,7 @@
 		}
 	};
 
+	$: ({ rate, reviseRate: { newRate = 0n, updatesAt = 0, rateStatus = '' } = {} } = jobData);
 	$: modalTitle =
 		rateStatus === ''
 			? 'INITIATE RATE REVISE'

--- a/src/lib/page-components/oyster/inventory/modals/CreateOrderModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/CreateOrderModal.svelte
@@ -26,6 +26,12 @@
 	export let modalFor: string;
 	export let preFilledData: Partial<CreateOrderPreFilledModel> = {};
 
+	const subtitle =
+		'Create a new order for a new job. You can create a new job by selecting the operator, instance type, region, and enclave image URL, and then approve and add funds to the job.';
+	const styles = {
+		inputText: 'px-4 py-2'
+	};
+
 	let duration = 0; //durationInSecs
 	let instanceCostScaled = 0n;
 	let invalidCost = false;
@@ -33,11 +39,12 @@
 	let bandwidthCostScaled = 0n;
 	let finalBandwidthRateScaled = 0n;
 	let totalCostScaled = 0n;
-
-	//loading states
-	let submitLoading = false;
 	let providerAddress: string | undefined = preFilledData.provider?.address;
-
+	let vcpu = '';
+	let memory = '';
+	let notServiceable = false;
+	//loading state
+	let submitLoading = false;
 	//initial states
 	let initialStates = {
 		merchant: {
@@ -173,9 +180,6 @@
 		region.value,
 		$oysterStore.allMarketplaceData
 	);
-	let vcpu = '';
-	let memory = '';
-	let notServiceable = false;
 
 	$: approved =
 		instanceCostScaled > 0n &&
@@ -209,13 +213,6 @@
 			: true;
 
 	$: totalRate = finalBandwidthRateScaled + (instanceRate || 0n);
-
-	const subtitle =
-		'Create a new order for a new job. You can create a new job by selecting the operator, instance type, region, and enclave image URL, and then approve and add funds to the job.';
-	const styles = {
-		inputText: 'px-4 py-2',
-		inputNumber: ''
-	};
 </script>
 
 <Modal {modalFor} onClose={resetInputs} padding={false} isScrollable={true}>

--- a/src/lib/page-components/oyster/inventory/modals/PastJobDetailsModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/PastJobDetailsModal.svelte
@@ -18,6 +18,17 @@
 	export let modalFor: string;
 	export let rowIndex: number;
 	export let jobData: OysterInventoryDataModel;
+
+	const styles = {
+		modalWidth: 'w-11/12 sm:max-w-[700px]',
+		textPrimary: 'text-primary'
+	};
+
+	const handleRedeploy = () => {
+		openModal(`create-order-modal-${rowIndex}`);
+		closeModal(modalFor);
+	};
+
 	$: ({
 		provider: { name, address },
 		instance,
@@ -32,16 +43,6 @@
 		depositHistory,
 		endEpochTime
 	} = jobData);
-
-	const handleRedeploy = () => {
-		openModal(`create-order-modal-${rowIndex}`);
-		closeModal(modalFor);
-	};
-
-	const styles = {
-		modalWidth: 'w-11/12 sm:max-w-[700px]',
-		textPrimary: 'text-primary'
-	};
 </script>
 
 <Modal {modalFor} modalWidth={styles.modalWidth} padding={false}>

--- a/src/lib/page-components/oyster/inventory/modals/StopJobModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/StopJobModal.svelte
@@ -19,8 +19,6 @@
 	export let modalFor: string;
 	export let jobData: OysterInventoryDataModel;
 
-	$: ({ reviseRate: { stopStatus = '', updatesAt = 0 } = {} } = jobData);
-
 	let submitLoading = false;
 	let cancelLoading = false;
 
@@ -50,6 +48,7 @@
 		handleJobStatusOnStopTimerEnd(jobData);
 	};
 
+	$: ({ reviseRate: { stopStatus = '', updatesAt = 0 } = {} } = jobData);
 	$: modalTitle =
 		stopStatus === '' || stopStatus === 'disabled'
 			? 'INITIATE STOP'

--- a/src/lib/page-components/oyster/inventory/modals/WithdrawFundsFromJobModal.svelte
+++ b/src/lib/page-components/oyster/inventory/modals/WithdrawFundsFromJobModal.svelte
@@ -26,7 +26,6 @@
 	let inputAmountIsValid = true;
 	let inValidMessage = '';
 	let updatedAmountInputDirty = false;
-
 	//loading states
 	let submitLoading = false;
 

--- a/src/lib/page-components/oyster/marketplace/TableFilter.svelte
+++ b/src/lib/page-components/oyster/marketplace/TableFilter.svelte
@@ -6,7 +6,6 @@
 	export let dataList: (string | number)[] = [];
 	export let value: string | number | undefined = '';
 	export let setValue: (value: string | number) => any;
-
 	export let title: string;
 
 	let suggestions: (string | number)[] = [];

--- a/src/lib/page-components/oyster/operator/OysterOperatorHistory.svelte
+++ b/src/lib/page-components/oyster/operator/OysterOperatorHistory.svelte
@@ -10,8 +10,6 @@
 		getSearchedInventoryData,
 		sortOysterOperatorHistory
 	} from '$lib/utils/helpers/oysterHelpers';
-	import { onDestroy } from 'svelte';
-	import type { Unsubscriber } from 'svelte/store';
 	import OysterTableCommon from '$lib/page-components/oyster/inventory/OysterTableCommon.svelte';
 	import OysterOperatorHistoryTableRow from '$lib/page-components/oyster/operator/OysterOperatorHistoryTableRow.svelte';
 	import { OYSTER_OPERATOR_JOBS_URL } from '$lib/utils/constants/urls';
@@ -22,8 +20,6 @@
 	let operatorHistoryData: OysterInventoryDataModel[] | undefined;
 	let sortingMap: Record<string, 'asc' | 'desc'> = {};
 
-	const itemsPerPage = TABLE_ITEMS_PER_PAGE;
-
 	const handlePageChange = (page: number) => {
 		activePage = page;
 	};
@@ -31,12 +27,6 @@
 	const onSearchClick = () => {
 		activePage = 1;
 	};
-
-	const unsubscribeOysterStore: Unsubscriber = oysterStore.subscribe(async (value) => {
-		operatorHistoryData = value.jobsData;
-		operatorHistoryData = operatorHistoryData?.filter((data) => !data.live);
-	});
-	onDestroy(unsubscribeOysterStore);
 
 	const handleSortData = (id: string) => {
 		if (sortingMap[id]) {
@@ -51,16 +41,15 @@
 		);
 	};
 
+	$: operatorHistoryData = $oysterStore.jobsData?.filter((data) => !data.live);
 	// get searched data based on searchInput
 	$: searchedData = getSearchedInventoryData(searchInput, operatorHistoryData);
-
 	// get page array based on inventory and itemsPerPage
-	$: pageCount = Math.ceil((searchedData?.length ?? 0) / itemsPerPage);
-
+	$: pageCount = Math.ceil((searchedData?.length ?? 0) / TABLE_ITEMS_PER_PAGE);
 	// get paginated data based on activePage
 	$: paginatedData = searchedData?.slice(
-		(activePage - 1) * itemsPerPage,
-		activePage * itemsPerPage
+		(activePage - 1) * TABLE_ITEMS_PER_PAGE,
+		activePage * TABLE_ITEMS_PER_PAGE
 	);
 </script>
 

--- a/src/lib/page-components/oyster/sub-components/AddFundsToJob.svelte
+++ b/src/lib/page-components/oyster/sub-components/AddFundsToJob.svelte
@@ -3,7 +3,10 @@
 	import AmountInputWithTitle from '$lib/components/inputs/AmountInputWithTitle.svelte';
 	import Select from '$lib/components/select/Select.svelte';
 	import { walletBalanceStore } from '$lib/data-stores/walletProviderStore';
-	import { OYSTER_DURATION_UNITS_LIST } from '$lib/utils/constants/oysterConstants';
+	import {
+		DEFAULT_OYSTER_DURATION_UNIT,
+		OYSTER_DURATION_UNITS_LIST
+	} from '$lib/utils/constants/oysterConstants';
 	import {
 		bigNumberToString,
 		convertHourlyRateToSecondlyRate,
@@ -21,15 +24,16 @@
 	import { oysterTokenMetadataStore, oysterRateMetadataStore } from '$lib/data-stores/oysterStore';
 
 	const durationUnitList = OYSTER_DURATION_UNITS_LIST.map((unit) => unit.label);
-	let durationUnit = 'Days';
+
 	export let instanceRate: bigint | undefined;
 	export let duration: number | undefined;
 	export let instanceCostScaled: bigint;
 	export let invalidCost = false;
 	export let instanceCostString = '';
 	export let isTotalRate = false;
-	export let durationUnitInSec = getDurationInSecondsForUnit(durationUnit);
+	export let durationUnitInSec = getDurationInSecondsForUnit(DEFAULT_OYSTER_DURATION_UNIT);
 
+	let durationUnit = DEFAULT_OYSTER_DURATION_UNIT;
 	let instanceRateString = '';
 
 	const updateRateString = (_instanceRate: bigint | undefined) => {

--- a/src/lib/page-components/oyster/sub-components/BandwidthSelector.svelte
+++ b/src/lib/page-components/oyster/sub-components/BandwidthSelector.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
 	import AmountInputWithTitle from '$lib/components/inputs/AmountInputWithTitle.svelte';
 	import Select from '$lib/components/select/Select.svelte';
-	import { OYSTER_BANDWIDTH_UNITS_LIST } from '$lib/utils/constants/oysterConstants';
+	import {
+		DEFAULT_BANDWIDTH_UNIT,
+		OYSTER_BANDWIDTH_UNITS_LIST
+	} from '$lib/utils/constants/oysterConstants';
 	import { bigNumberToString } from '$lib/utils/helpers/conversionHelper';
 	import { getBandwidthRateForRegion } from '$lib/utils/data-modifiers/oysterModifiers';
 	import { oysterTokenMetadataStore, oysterRateMetadataStore } from '$lib/data-stores/oysterStore';
@@ -15,7 +18,7 @@
 	export let totalCostScaled = 0n;
 
 	let bandwidth = '';
-	let bandwidthUnit = 'KB/s';
+	let bandwidthUnit = DEFAULT_BANDWIDTH_UNIT;
 	let bandwidthCostString = '';
 
 	const bandwidthUnitList = OYSTER_BANDWIDTH_UNITS_LIST.map((unit) => unit.label);
@@ -47,7 +50,6 @@
 					4
 			  )
 			: '';
-
 	$: totalCostScaled = bandwidthCostScaled + instanceCostScaled;
 	$: totalCost = totalCostScaled / $oysterRateMetadataStore.oysterRateScalingFactor;
 	$: totalAmountString = !(totalCost === 0n)

--- a/src/lib/page-components/oyster/sub-components/MetadetailsForNewOrder.svelte
+++ b/src/lib/page-components/oyster/sub-components/MetadetailsForNewOrder.svelte
@@ -23,19 +23,13 @@
 	export let vcpu: string;
 	export let memory: string;
 	export let providerAddress: string | undefined;
-	export let handleChange = () => {
-		doNothing();
-	};
+	export let handleChange = () => doNothing();
 	export let notServiceable = false;
 
 	let filters: Partial<OysterFiltersModel> = getCreateOrderInstanceRegionFilters(
 		providerAddress,
 		allMarketplaceData
 	);
-
-	$: merchantAddressList = [
-		...new Set(allMarketplaceData.map((data) => data.provider.address) ?? [])
-	];
 
 	const handleInstanceChange = async (value: string | number) => {
 		instance.value = value as string;
@@ -146,6 +140,9 @@
 		arch.value = val;
 	}
 
+	$: merchantAddressList = [
+		...new Set(allMarketplaceData.map((data) => data.provider.address) ?? [])
+	];
 	$: validInstanceParameters = !merchant.error && !instance.error && !region.error;
 	$: instanceData = validInstanceParameters
 		? getInstanceMetadatDataForOperator(

--- a/src/lib/page-components/receiver-staking/buttons/UnstakeButton.svelte
+++ b/src/lib/page-components/receiver-staking/buttons/UnstakeButton.svelte
@@ -2,8 +2,10 @@
 	import ModalButton from '$lib/atoms/modals/ModalButton.svelte';
 	import UnstakeModal from '$lib/page-components/receiver-staking/UnstakeModal.svelte';
 
-	let modalFor = 'unstake-modal';
 	export let disabled = false;
+
+	let modalFor = 'unstake-modal';
+
 	const styles = {
 		buttonLarge: 'h-14 text-base font-semibold w-full'
 	};

--- a/src/lib/page-components/receiver-staking/sub-components/DataRowCard.svelte
+++ b/src/lib/page-components/receiver-staking/sub-components/DataRowCard.svelte
@@ -5,6 +5,7 @@
 	import { bigNumberToString } from '$lib/utils/helpers/conversionHelper';
 
 	export let data: { title: string; value: bigint };
+
 	const styles = {
 		itemCard: 'w-full',
 		dataRow: 'flex items-center justify-between',

--- a/src/lib/page-components/receiver-staking/sub-components/InQueuedPopOver.svelte
+++ b/src/lib/page-components/receiver-staking/sub-components/InQueuedPopOver.svelte
@@ -8,55 +8,34 @@
 		receiverStakingStore,
 		updateEpochOnTimerEndInReceiverStakingStore
 	} from '$lib/data-stores/receiverStakingStore';
-	import type { EpochCycleStore, ReceiverStakingData } from '$lib/types/storeTypes';
 	import { epochToDurationString } from '$lib/utils/helpers/conversionHelper';
-	import { onDestroy } from 'svelte';
-	import type { Unsubscriber } from 'svelte/store';
 
 	export let iconWidth = 12;
 
-	let localEpochCycle: EpochCycleStore = 0;
-	const unsubscribeEpochCycleStore: Unsubscriber = epochCycleStore.subscribe(
-		async (value: EpochCycleStore) => {
-			localEpochCycle = value;
-		}
-	);
-
-	let receiverData: ReceiverStakingData;
-	const unsubscribeReceiverStakedStore: Unsubscriber = receiverStakingStore.subscribe(
-		async (value: ReceiverStakingData) => {
-			receiverData = value;
-		}
-	);
-
-	onDestroy(unsubscribeReceiverStakedStore);
-	onDestroy(unsubscribeEpochCycleStore);
-
 	const description = `The total amount of POND in queue to be staked to the receiver's address.`;
 	const subtitle = `Queued POND will be staked`;
-
-	//if queued balance is greater than 0 then inQueue is true
-	$: inQueue = receiverData.queuedBalance > 0;
-
-	//end epoch time is the time when next epoch cycle will start
-	$: endEpochTime =
-		receiverData.epochData.startTime + receiverData.epochData.epochLength * localEpochCycle;
+	const styles = {
+		subtitle: 'py-2 px-3 text-left bg-black text-white rounded'
+	};
 
 	const onTimerEnd = () => {
 		inQueue = false;
 		updateEpochOnTimerEndInReceiverStakingStore();
 	};
 
-	const styles = {
-		subtitle: 'py-2 px-3 text-left bg-black text-white rounded'
-	};
+	//if queued balance is greater than 0 then inQueue is true
+	$: inQueue = $receiverStakingStore.queuedBalance > 0;
+	//end epoch time is the time when next epoch cycle will start
+	$: endEpochTime =
+		$receiverStakingStore.epochData.startTime +
+		$receiverStakingStore.epochData.epochLength * $epochCycleStore;
 </script>
 
 <PopOver>
 	<img slot="icon" src={staticImages.Info} alt="Info" width={iconWidth} />
 	<svelte:fragment slot="content">
 		<div class={styles.subtitle}>
-			{#if inQueue && localEpochCycle > 0}
+			{#if inQueue && $epochCycleStore > 0}
 				<Timer timerId={`timer-for-staking-in-queue`} {onTimerEnd} {endEpochTime}>
 					<div slot="active" let:timer>
 						<Text

--- a/src/lib/page-components/receiver-staking/sub-components/ModalApproveButton.svelte
+++ b/src/lib/page-components/receiver-staking/sub-components/ModalApproveButton.svelte
@@ -10,7 +10,6 @@
 
 	//approved if input amount is greater than 0 and approved amount is greater than input amount
 	$: approved = inputAmount > 0n && approvedAmount >= inputAmount;
-
 	$: styleClass = `${buttonClasses.text} h-10 text-xl font-semibold ${
 		disabled ? (approved ? ' text-primary' : ' text-primary text-opacity-30') : 'text-primary'
 	}`;

--- a/src/lib/page-components/receiver-staking/sub-components/SignerAddressModal.svelte
+++ b/src/lib/page-components/receiver-staking/sub-components/SignerAddressModal.svelte
@@ -13,13 +13,13 @@
 	import { DEFAULT_RECEIVER_STAKING_DATA } from '$lib/utils/constants/storeDefaults';
 	import { closeModal, isAddressValid } from '$lib/utils/helpers/commonHelper';
 
+	export let modalFor: string;
+
 	let updatedSignerAddress: Address = '';
 	let submitLoading = false;
 	let updatedSignerAddressInputDirty = false;
 	let signerAddressIsValid: boolean;
 	let signerAddressIsUnique = false;
-
-	export let modalFor: string;
 
 	const subtitle =
 		'This is the address used by the receiver to give tickets to clusters. The signer address can be found in the receiver client.';

--- a/src/lib/utils/constants/oysterConstants.ts
+++ b/src/lib/utils/constants/oysterConstants.ts
@@ -302,6 +302,8 @@ export const OYSTER_DURATION_UNITS_LIST = [
 	}
 ];
 
+export const DEFAULT_OYSTER_DURATION_UNIT = 'Days';
+
 export const OYSTER_BANDWIDTH_UNITS_LIST = [
 	{
 		label: 'KB/s',
@@ -319,3 +321,5 @@ export const OYSTER_BANDWIDTH_UNITS_LIST = [
 		value: 1
 	}
 ];
+
+export const DEFAULT_BANDWIDTH_UNIT = 'KB/s';

--- a/src/routes/bridge/+page.svelte
+++ b/src/routes/bridge/+page.svelte
@@ -10,6 +10,7 @@
 	import BridgeDashboard from '$lib/page-components/bridge/BridgeDashboard.svelte';
 	import { modifyAllowancesData } from '$lib/utils/data-modifiers/subgraphModifier';
 
+	// TODO: move this to +layout.ts and update the allowance function to fetch from correct subgraph
 	async function init() {
 		const [allowancesData, requestedMPond] = await Promise.all([
 			getPondAndMPondBridgeAllowancesFromSubgraph(

--- a/src/routes/relay/+layout.svelte
+++ b/src/routes/relay/+layout.svelte
@@ -2,6 +2,10 @@
 	import PageWrapper from '$lib/components/wrapper/PageWrapper.svelte';
 </script>
 
+<svelte:head>
+	<title>Marlin Receiver Portal</title>
+</svelte:head>
+
 <PageWrapper>
 	<slot />
 </PageWrapper>

--- a/src/routes/relay/receiver/staking/+page.svelte
+++ b/src/routes/relay/receiver/staking/+page.svelte
@@ -52,10 +52,6 @@
 	});
 </script>
 
-<svelte:head>
-	<title>Marlin Receiver Portal</title>
-</svelte:head>
-
 {#if chainSupported}
 	<StakeDashboard />
 {:else}


### PR DESCRIPTION
### TLDR;
This PR is created to improve the DX and debugging process by replacing explicit subscriptions using Svelte's `$` notation, organizing stuff inside the `<script></script>` tags, cleaning up the usage of constants and some other quality of life changes.

## The PR does the following:
### For variables which were previously assigned inside the subscription, we just use the $ notation to assign them reactively in places that the variable was being used.
Our project was using explicit subscriptions and cleanup function (unsubscribe methods) in many places. This was leading to increased lines of code making each component difficult to sift through without getting any actual benefit from it.

Before refactor
```ts
// ❌ this subscription has no value 
const unsubscribeWalletBalanceStore = walletBalanceStore.subscribe((value) => {
	walletMPondBalance = value.mpond; 
});
$: unrequestedMPondBalance = walletMPondBalance - requestedMPond;
// we also have to manually unsubscribe
onDestroy(unsubscribeWalletBalanceStore);
```
After refactor
```ts
// ✅ using $ notation to directly assign the values wherever needed 
$: unrequestedMPondBalance = $walletBalanceStore.mpond - requestedMPond;
```
### Re-order things inside the `<script></script>` 
Having a structure for code that resided inside the `<script></script>` tags make the code base more predictable, increase skimmability and removes the need to think about how to organize stuff
   - imports
   - `onMount` calls
   - exported variables
   - `const` variables (would remove many `const` declarations in coming PRs, since they majorly consists of styles, which are better defined explicitly in markup)
   - `let` variables
   - functions
   - `$:` reactive statements + reactive blocks at the bottom of the page since they are executed at last
   - `onDestroy` calls

### Removed constants being reassigned to a variable and then being used
In many places, especially in case of tables I saw that the number of items in a table was being controlled by a constant but by being assigned to another variable.

Before refactor
```ts
// ❌ this doesn't make sense, since while refactoring we already check all the references to a variable
import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
const itemsPerPage = TABLE_ITEMS_PER_PAGE;
$: pageCount = Math.ceil((searchedData?.length ?? 0) / itemsPerPage);
```

After refactor
```ts
// ✅  we remove the additional assignment
import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
$: pageCount = Math.ceil((searchedData?.length ?? 0) / TABLE_ITEMS_PER_PAGE);
```

### Moved `<svelte:head>` for receiver portal to +layout.ts
This is a change that can be further updated on a finer level. Basically each page in our site should have a title. I have made the title page of both `Receiver Staking` and `Receiver Rewards` the same i.e. `Receiver Portal`.

 P.S. I know this is another large P.R. me sa isaa sowwey 🤥 