### PR TITLE
bug-fix: new job not showing inventory fix

### DIFF
--- a/src/lib/data-stores/oysterStore.ts
+++ b/src/lib/data-stores/oysterStore.ts
@@ -11,6 +11,7 @@ import { derived, writable, type Writable } from 'svelte/store';
 import { chainConfigStore } from '$lib/data-stores/chainProviderStore';
 import { DEFAULT_CURRENCY_DECIMALS } from '$lib/utils/constants/constants';
 import type { TokenMetadata } from '$lib/types/environmentTypes';
+import { combineAndDeduplicateJobs } from '$lib/utils/helpers/oysterHelpers';
 
 export const oysterStore: Writable<OysterStore> = writable(DEFAULT_OYSTER_STORE);
 export const oysterTokenMetadataStore = derived([chainConfigStore], ([$chainConfigStore]) => {
@@ -454,8 +455,9 @@ export function initializeInventoryDataInOysterStore(oysterJobs: OysterInventory
 	oysterStore.update((value) => {
 		return {
 			...value,
-			jobsData: [...oysterJobs],
+			jobsData: [...combineAndDeduplicateJobs(oysterJobs, value.jobsData)],
 			oysterStoreLoaded: true
 		};
 	});
 }
+

--- a/src/lib/utils/helpers/oysterHelper.test.ts
+++ b/src/lib/utils/helpers/oysterHelper.test.ts
@@ -21,8 +21,11 @@ import {
 	sortOysterOperatorHistory,
 	getSearchAndFilteredMarketplaceData,
 	getAllFiltersListforMarketplaceData,
-	sortOysterOperatorInventory
+	sortOysterOperatorInventory,
+	addJobsToMap,
+	combineAndDeduplicateJobs
 } from './oysterHelpers';
+
 import type {
 	OysterInventoryDataModel,
 	OysterMarketplaceDataModel
@@ -4990,5 +4993,46 @@ describe('getDurationInSecondsForUnit', () => {
 		expect(getDurationInSecondsForUnit('Days')).toBe(86400);
 		expect(getDurationInSecondsForUnit('Hours')).toBe(3600);
 		expect(getDurationInSecondsForUnit('Minutes')).toBe(60);
+	});
+});
+
+
+// Mock OysterInventoryDataModel
+type OysterInventoryDataModel = {
+	id: string;
+	createdAt: number;
+};
+
+describe('addJobsToMap', () => {
+	it('should add jobs to the map with the correct id', () => {
+		const map = new Map();
+		const jobs: OysterInventoryDataModel[] = [
+			{ id: 'job1', createdAt: Date.now() },
+			{ id: 'job2', createdAt: Date.now() },
+		];
+
+		addJobsToMap(jobs, map);
+		expect(map.size).toBe(2);
+		expect(map.get('job1')).toBe(jobs[0]);
+		expect(map.get('job2')).toBe(jobs[1]);
+	});
+});
+
+describe('combineAndDeduplicateJobs', () => {
+	it('should combine and deduplicate jobs based on id and sort by createdAt descending', () => {
+		const earlierJobs: OysterInventoryDataModel[] = [
+			{ id: 'job1', createdAt: 1000 },
+			{ id: 'job2', createdAt: 2000 },
+		];
+		const newJobs: OysterInventoryDataModel[] = [
+			{ id: 'job2', createdAt: 3000 },
+			{ id: 'job3', createdAt: 4000 },
+		];
+
+		const combinedJobs = combineAndDeduplicateJobs(earlierJobs, newJobs);
+		expect(combinedJobs.length).toBe(3);
+		expect(combinedJobs[0].id).toBe('job3');
+		expect(combinedJobs[1].id).toBe('job2');
+		expect(combinedJobs[2].id).toBe('job1');
 	});
 });

--- a/src/lib/utils/helpers/oysterHelper.test.ts
+++ b/src/lib/utils/helpers/oysterHelper.test.ts
@@ -4997,16 +4997,10 @@ describe('getDurationInSecondsForUnit', () => {
 });
 
 
-// Mock OysterInventoryDataModel
-type OysterInventoryDataModel = {
-	id: string;
-	createdAt: number;
-};
-
 describe('addJobsToMap', () => {
 	it('should add jobs to the map with the correct id', () => {
 		const map = new Map();
-		const jobs: OysterInventoryDataModel[] = [
+		const jobs: Pick<OysterInventoryDataModel, 'id' | 'createdAt'>[] = [
 			{ id: 'job1', createdAt: Date.now() },
 			{ id: 'job2', createdAt: Date.now() },
 		];
@@ -5020,11 +5014,11 @@ describe('addJobsToMap', () => {
 
 describe('combineAndDeduplicateJobs', () => {
 	it('should combine and deduplicate jobs based on id and sort by createdAt descending', () => {
-		const earlierJobs: OysterInventoryDataModel[] = [
+		const earlierJobs: Pick<OysterInventoryDataModel, 'id' | 'createdAt'>[] = [
 			{ id: 'job1', createdAt: 1000 },
 			{ id: 'job2', createdAt: 2000 },
 		];
-		const newJobs: OysterInventoryDataModel[] = [
+		const newJobs: Pick<OysterInventoryDataModel, 'id' | 'createdAt'>[] = [
 			{ id: 'job2', createdAt: 3000 },
 			{ id: 'job3', createdAt: 4000 },
 		];

--- a/src/lib/utils/helpers/oysterHelpers.ts
+++ b/src/lib/utils/helpers/oysterHelpers.ts
@@ -282,9 +282,9 @@ export const getSearchAndFilteredMarketplaceData = (
 		allMarketplaceData = allMarketplaceData.filter((item) => {
 			return exactMatch
 				? item.provider.address.toLowerCase() === value ||
-						item.provider.name?.toLowerCase() === value
+				item.provider.name?.toLowerCase() === value
 				: item.provider.address.toLowerCase().includes(value) ||
-						item.provider.name?.toLowerCase()?.includes(value);
+				item.provider.name?.toLowerCase()?.includes(value);
 		});
 	}
 
@@ -294,7 +294,7 @@ export const getSearchAndFilteredMarketplaceData = (
 			return exactMatch
 				? item.region.toLowerCase() === value || item.regionName.toLowerCase() === value
 				: item.region.toLowerCase().includes(value) ||
-						item.regionName.toLowerCase().includes(value);
+				item.regionName.toLowerCase().includes(value);
 		});
 	}
 
@@ -476,3 +476,19 @@ export function getBandwidthFromRateAndRegion(bandwidthRate: bigint, region: str
 export const getDurationInSecondsForUnit = (durationUnit: OysterDurationUnits) => {
 	return OYSTER_DURATION_UNITS_LIST.find((unit) => unit.label === durationUnit)?.value ?? 1;
 };
+
+export const combineAndDeduplicateJobs = (jobsArray1: OysterInventoryDataModel[], jobsArray2: OysterInventoryDataModel[]) => {
+	const combinedUniqueObjectsMap = new Map();
+
+	// Helper function to add objects to the map, avoiding duplicates
+	const addObjectsToMap = (jobs: OysterInventoryDataModel[]) => {
+		jobs.forEach(job => combinedUniqueObjectsMap.set(job.id, job));
+	};
+
+	// Add objects from both arrays to the map
+	addObjectsToMap(jobsArray1);
+	addObjectsToMap(jobsArray2);
+
+	// Convert the map values back to an array
+	return Array.from(combinedUniqueObjectsMap.values()).sort((job1, job2) => job2.createdAt - job1.createdAt);
+}

--- a/src/lib/utils/helpers/oysterHelpers.ts
+++ b/src/lib/utils/helpers/oysterHelpers.ts
@@ -478,7 +478,7 @@ export const getDurationInSecondsForUnit = (durationUnit: OysterDurationUnits) =
 	return OYSTER_DURATION_UNITS_LIST.find((unit) => unit.label === durationUnit)?.value ?? 1;
 };
 
-const addJobsToMap = (jobs: OysterInventoryDataModel[], map: Map<BytesLike, OysterInventoryDataModel>) => {
+export const addJobsToMap = (jobs: OysterInventoryDataModel[], map: Map<BytesLike, OysterInventoryDataModel>) => {
 	jobs.forEach(job => map.set(job.id, job));
 };
 

--- a/src/lib/utils/helpers/oysterHelpers.ts
+++ b/src/lib/utils/helpers/oysterHelpers.ts
@@ -19,6 +19,7 @@ import { getBandwidthRateForRegion } from '$lib/utils/data-modifiers/oysterModif
 import { isInputAmountValid } from '$lib/utils/helpers/commonHelper';
 import type { SortDirection } from '$lib/types/componentTypes';
 import { REGION_NAME_CONSTANTS } from '../constants/regionNameConstants';
+import type { BytesLike } from 'ethers';
 
 export const getSearchedInventoryData = (
 	searchInput: string,
@@ -477,18 +478,18 @@ export const getDurationInSecondsForUnit = (durationUnit: OysterDurationUnits) =
 	return OYSTER_DURATION_UNITS_LIST.find((unit) => unit.label === durationUnit)?.value ?? 1;
 };
 
+const addJobsToMap = (jobs: OysterInventoryDataModel[], map: Map<BytesLike, OysterInventoryDataModel>) => {
+	jobs.forEach(job => map.set(job.id, job));
+};
+
 export const combineAndDeduplicateJobs = (earlierJobs: OysterInventoryDataModel[], newJobs: OysterInventoryDataModel[]) => {
 	const combinedUniqueObjectsMap = new Map();
 
-	// Helper function to add objects to the map, avoiding duplicates
-	const addObjectsToMap = (jobs: OysterInventoryDataModel[]) => {
-		jobs.forEach(job => combinedUniqueObjectsMap.set(job.id, job));
-	};
-
 	// Add objects from both arrays to the map
-	addObjectsToMap(earlierJobs);
-	addObjectsToMap(newJobs);
+	addJobsToMap(earlierJobs, combinedUniqueObjectsMap);
+	addJobsToMap(newJobs, combinedUniqueObjectsMap);
 
 	// Convert the map values back to an array
 	return Array.from(combinedUniqueObjectsMap.values()).sort((job1, job2) => job2.createdAt - job1.createdAt);
 }
+

--- a/src/lib/utils/helpers/oysterHelpers.ts
+++ b/src/lib/utils/helpers/oysterHelpers.ts
@@ -477,7 +477,7 @@ export const getDurationInSecondsForUnit = (durationUnit: OysterDurationUnits) =
 	return OYSTER_DURATION_UNITS_LIST.find((unit) => unit.label === durationUnit)?.value ?? 1;
 };
 
-export const combineAndDeduplicateJobs = (jobsArray1: OysterInventoryDataModel[], jobsArray2: OysterInventoryDataModel[]) => {
+export const combineAndDeduplicateJobs = (earlierJobs: OysterInventoryDataModel[], newJobs: OysterInventoryDataModel[]) => {
 	const combinedUniqueObjectsMap = new Map();
 
 	// Helper function to add objects to the map, avoiding duplicates
@@ -486,8 +486,8 @@ export const combineAndDeduplicateJobs = (jobsArray1: OysterInventoryDataModel[]
 	};
 
 	// Add objects from both arrays to the map
-	addObjectsToMap(jobsArray1);
-	addObjectsToMap(jobsArray2);
+	addObjectsToMap(earlierJobs);
+	addObjectsToMap(newJobs);
 
 	// Convert the map values back to an array
 	return Array.from(combinedUniqueObjectsMap.values()).sort((job1, job2) => job2.createdAt - job1.createdAt);


### PR DESCRIPTION
## Description:
When creating an order from marketplace, after creation,  it navigates to inventory dashboard and newly created job doesn't show up. 

## Fix: 
Upon creation of an order, the order details go into the oyster store. 
And upon navigation to inventory dashboard, both that data is merged with the newly created order as a resultant array of jobs.