### PR TITLE
PR to refactor table css classes

### DIFF
--- a/src/lib/atoms/v2/componentClasses.ts
+++ b/src/lib/atoms/v2/componentClasses.ts
@@ -26,16 +26,11 @@ export const buttonClasses = {
 		'btn btn-sm px-2 border-none bg-base-200 hover:bg-base-300 disabled:bg-base-200 disabled:text-primary disabled:curson-not-allowed disabled:cursor-not-allowed'
 };
 
-// TODO @souvikmishra: refactor these later
-export const tableCellClasses = {
+export const tableClasses = {
 	heading: 'text-primary text-sm font-semibold px-2 pb-4',
-	row: 'font-semibold text-base py-6 whitespace-nowrap',
-	rowNormal:
-		'text-left font-normal text-sm py-[23.5px] whitespace-nowrap leading-none border-b border-[#D9DADE]',
-	mainRow: ' border-b border-[#D9DADE] last:border-none',
-	rowCell: 'text-left font-normal text-sm py-[23.5px] whitespace-nowrap leading-none',
-	rowMini: 'font-normal text-xs py-1 whitespace-nowrap',
-	rowWithIcon: 'flex flex-col items-center justify-start',
+	row: 'border-b border-[#D9DADE] font-normal whitespace-nowrap last:border-b-0',
+	cell: 'text-left text-sm py-[23.5px] leading-none',
+	cellMini: 'text-xs py-1',
 	empty: 'text-base text-center p-4 w-full'
 };
 

--- a/src/lib/components/v2/table-cells/TableDataCell.svelte
+++ b/src/lib/components/v2/table-cells/TableDataCell.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import { cn } from '$lib/utils/helpers/commonHelper';
 	export let styleClass = '';
 </script>
 
-<td class={cn(tableCellClasses.rowNormal, styleClass)} data-testid="table-data-cell">
+<td class={cn(tableClasses.rowNormal, styleClass)} data-testid="table-data-cell">
 	<slot />
 </td>

--- a/src/lib/components/v2/table-cells/TableDataWithButton.svelte
+++ b/src/lib/components/v2/table-cells/TableDataWithButton.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import { cn } from '$lib/utils/helpers/commonHelper';
 	export let styleClass = '';
 	export let firstRow: boolean = false;
 </script>
 
 <td class={cn(styleClass, firstRow ? 'pl-4' : '')} data-testid="table-data-with-button">
-	<div class={tableCellClasses.rowNormal}>
+	<div class={tableClasses.rowNormal}>
 		<div class="m-auto flex h-[35px] items-center">
 			<slot name="line1" />
 		</div>

--- a/src/lib/page-components/v2/bridge/history/HistoryTableCommon.svelte
+++ b/src/lib/page-components/v2/bridge/history/HistoryTableCommon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import Table from '$lib/atoms/v2/table/Table.svelte';
 	import HeaderConnectWallet from '$lib/components/v2/header/sub-components/HeaderConnectWallet.svelte';
 	import LoadingAnimatedPing from '$lib/components/loading/LoadingAnimatedPing.svelte';
@@ -54,7 +54,7 @@
 			</tbody>
 		</Table>
 		{#if noDataFound}
-			<div class={tableCellClasses.empty}>No data found!</div>
+			<div class={tableClasses.empty}>No data found!</div>
 		{/if}
 	{/if}
 </div>

--- a/src/lib/page-components/v2/bridge/history/MPondTableRow.svelte
+++ b/src/lib/page-components/v2/bridge/history/MPondTableRow.svelte
@@ -25,6 +25,7 @@
 	import { getTxnUrl } from '$lib/utils/helpers/commonHelper';
 	import ModalButton from '$lib/atoms/modals/ModalButton.svelte';
 	import Tooltip from '$lib/atoms/v2/tooltips/Tooltip.svelte';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 
 	export let rowData: MPondToPondHistoryDataModel;
 	export let rowIndex: number;
@@ -95,7 +96,7 @@
 	$: endEpochTime = getTimerEpoch(currentCycle, eligibleCycles);
 </script>
 
-<tr class="border-b border-[#e5e5e5] last:border-b-0">
+<tr class={tableClasses.row}>
 	<TableDataWithButton firstRow>
 		<svelte:fragment slot="line1">
 			<div class="flex items-center gap-2">

--- a/src/lib/page-components/v2/bridge/history/PondToMPondHistoryData.svelte
+++ b/src/lib/page-components/v2/bridge/history/PondToMPondHistoryData.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/v2/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import type { PondToMPondHistoryDataModel } from '$lib/types/bridgeComponentType';
 	import { POND_TO_MPOND_TABLE_HEADER } from '$lib/utils/constants/v2/bridgeConstants';
 	import {
@@ -53,14 +53,12 @@
 	>
 		{#if paginatedData?.length}
 			{#each paginatedData as row}
-				<tr class={tableCellClasses.mainRow}>
-					<td class={cn(tableCellClasses.rowCell, 'block pl-4')}
-						>{epochSecToString(row.timestamp)}</td
-					>
-					<td class={tableCellClasses.rowCell}
+				<tr class={tableClasses.mainRow}>
+					<td class={cn(tableClasses.cell, 'block pl-4')}>{epochSecToString(row.timestamp)}</td>
+					<td class={tableClasses.cell}
 						>{bigNumberToString(row.pondConverted, DEFAULT_CURRENCY_DECIMALS, POND_PRECISIONS)}</td
 					>
-					<td class={tableCellClasses.rowCell}
+					<td class={tableClasses.cell}
 						>{bigNumberToString(row.mpondReceived, DEFAULT_CURRENCY_DECIMALS, MPOND_PRECISIONS)}</td
 					>
 				</tr>

--- a/src/lib/page-components/v2/oyster/inventory/OysterInventoryExpandedTableRow.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterInventoryExpandedTableRow.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import ModalButton from '$lib/atoms/v2/modals/ModalButton.svelte';
+	import type { OysterInventoryDataModel } from '$lib/types/oysterComponentType';
+	import { slide } from 'svelte/transition';
+	import AddFundsToJobModal from './modals/AddFundsToJobModal.svelte';
+	import AmendRateModal from './modals/AmendRateModal.svelte';
+	import JobDetailsModal from './modals/JobDetailsModal.svelte';
+	import StopJobModal from './modals/StopJobModal.svelte';
+	import WithdrawFundsFromJobModal from './modals/WithdrawFundsFromJobModal.svelte';
+
+	export let rowData: OysterInventoryDataModel;
+	export let expandedRows: Set<string>;
+
+	$: ({
+		id,
+		endEpochTime, // epoch time in seconds based on duration left,
+		// newRate is being passed to the modal for the amend rate modal and is not used here
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		reviseRate: { newRate = null, rateStatus = '', stopStatus = '' } = {}
+	} = rowData);
+
+	$: isJobFinished = !(Math.floor(endEpochTime - Date.now() / 1000) > 0);
+	$: isOpen = expandedRows.has(id.toString());
+	$: closeButtonText =
+		stopStatus === '' || stopStatus === 'disabled'
+			? 'Initiate Stop'
+			: stopStatus === 'pending'
+				? 'Cancel Stop'
+				: 'Confirm Stop';
+
+	$: amendRateButtonText =
+		rateStatus === ''
+			? 'Initiate rate amend'
+			: rateStatus === 'pending'
+				? 'Cancel rate amend'
+				: 'Confirm rate amend';
+</script>
+
+{#if isOpen}
+	<td colspan="12">
+		<div transition:slide={{ duration: 400 }} class="mb-8 mt-4 flex gap-4 px-8">
+			{#if !isJobFinished}
+				<ModalButton
+					variant="filled"
+					size="small"
+					modalFor="job-add-funds-modal-{id}"
+					disabled={isJobFinished}
+				>
+					Add Funds
+				</ModalButton>
+				<ModalButton
+					variant="outlined"
+					size="small"
+					modalFor="job-stop-modal-{id}"
+					disabled={isJobFinished}
+				>
+					{closeButtonText}
+				</ModalButton>
+				<ModalButton
+					variant="outlined"
+					size="small"
+					modalFor="job-withdraw-fund-modal-{id}"
+					disabled={isJobFinished}
+				>
+					Withdraw
+				</ModalButton>
+				<ModalButton
+					variant="outlined"
+					size="small"
+					modalFor="job-amend-rate-modal-{id}"
+					disabled={isJobFinished}
+				>
+					{amendRateButtonText}
+				</ModalButton>
+			{/if}
+			<ModalButton variant="outlined" size="small" modalFor="job-details-modal-{id}">
+				Details
+			</ModalButton>
+		</div>
+	</td>
+{/if}
+
+<JobDetailsModal bind:jobData={rowData} modalFor="job-details-modal-{id}" />
+<AddFundsToJobModal bind:jobData={rowData} modalFor="job-add-funds-modal-{id}" />
+<WithdrawFundsFromJobModal bind:jobData={rowData} modalFor="job-withdraw-fund-modal-{id}" />
+<StopJobModal bind:jobData={rowData} modalFor="job-stop-modal-{id}" />
+<AmendRateModal bind:jobData={rowData} modalFor="job-amend-rate-modal-{id}" />

--- a/src/lib/page-components/v2/oyster/inventory/OysterInventoryHistoryTableRow.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterInventoryHistoryTableRow.svelte
@@ -12,7 +12,7 @@
 	import { getColorHexByVariant } from '$lib/utils/helpers/componentHelper';
 	import { oysterTokenMetadataStore } from '$lib/data-stores/oysterStore';
 	import ModalButton from '$lib/atoms/modals/ModalButton.svelte';
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 
 	export let rowData: OysterInventoryDataModel;
 	export let rowIndex: number;
@@ -33,42 +33,42 @@
 </script>
 
 <tr class="main-row hover:bg-base-200">
-	<td class={tableCellClasses.row}>
+	<td class={tableClasses.cell}>
 		<NameWithAddress {name} {address} {rowIndex} {isCreditJob}>
 			<svelte:fragment slot="copyIcon">
-				<div class="copy-icon cursor-pointer">
+				<div class="hidden cursor-pointer group-hover:flex">
 					<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
 				</div>
 			</svelte:fragment>
 		</NameWithAddress>
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		{instance ?? 'N/A'}
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		{region ?? 'N/A'}
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		{$oysterTokenMetadataStore.symbol}{bigNumberToString(
 			totalDeposit,
 			$oysterTokenMetadataStore.decimal
 		)}
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		{$oysterTokenMetadataStore.symbol}{bigNumberToString(
 			amountUsed,
 			$oysterTokenMetadataStore.decimal
 		)}
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		{$oysterTokenMetadataStore.symbol}{bigNumberToString(refund, $oysterTokenMetadataStore.decimal)}
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		<Tooltip tooltipText={epochToDurationString(endEpochTime - createdAt)}>
 			{epochToDurationString(endEpochTime - createdAt, true)}
 		</Tooltip>
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		<div
 			class="mx-auto w-24 rounded py-1 text-sm capitalize text-white"
 			style="background-color: {statusColor}"
@@ -76,7 +76,7 @@
 			{status}
 		</div>
 	</td>
-	<td class={tableCellClasses.rowNormal}>
+	<td class={tableClasses.cell}>
 		<ModalButton
 			variant="tableConvertButton"
 			styleClass="w-fit ml-4 mr-6"
@@ -86,21 +86,3 @@
 </tr>
 <PastJobDetailsModal modalFor="job-history-details-{rowIndex}" jobData={rowData} {rowIndex} />
 <CreateOrderModal modalFor="create-order-modal-{rowIndex}" preFilledData={rowData} />
-
-<style>
-	/* TODO: migrate these classes to tailwind and then refactor the copy to clipboard functionality */
-	.main-row {
-		border-bottom: 1px solid #e5e5e5;
-	}
-
-	.main-row:last-child {
-		border-bottom: none;
-	}
-
-	.main-row:hover .copy-icon {
-		display: flex;
-	}
-	.main-row .copy-icon {
-		display: none;
-	}
-</style>

--- a/src/lib/page-components/v2/oyster/inventory/OysterInventoryPage.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterInventoryPage.svelte
@@ -5,6 +5,7 @@
 	import { oysterStore } from '$lib/data-stores/oysterStore';
 	import { connected } from '$lib/data-stores/walletProviderStore';
 	import OysterInventoryTableRow from '$lib/page-components/v2/oyster/inventory/OysterInventoryTableRow.svelte';
+	import OysterInventoryExpandedTableRow from '$lib/page-components/v2/oyster/inventory/OysterInventoryExpandedTableRow.svelte';
 	import type { OysterInventorySortKeys } from '$lib/types/oysterComponentType';
 	import { OYSTER_INVENTORY_TABLE_HEADER } from '$lib/utils/constants/v2/oysterConstants';
 	import { getSearchedInventoryData, sortOysterInventory } from '$lib/utils/helpers/oysterHelpers';
@@ -12,6 +13,7 @@
 	import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
 	import { ROUTES } from '$lib/utils/constants/v2/urls';
 	import Button from '$lib/atoms/v2/buttons/Button.svelte';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 
 	let searchInput = '';
 	let activePage = 1;
@@ -80,7 +82,12 @@
 >
 	{#if paginatedData?.length}
 		{#each paginatedData as rowData, rowIndex (rowData.id)}
-			<OysterInventoryTableRow {rowData} {rowIndex} bind:expandedRows />
+			<tr class="group hover:bg-base-200">
+				<OysterInventoryTableRow {rowData} {rowIndex} bind:expandedRows />
+			</tr>
+			<tr class={tableClasses.mainRow}>
+				<OysterInventoryExpandedTableRow {rowData} {expandedRows} />
+			</tr>
 		{/each}
 	{/if}
 </OysterTableCommon>

--- a/src/lib/page-components/v2/oyster/inventory/OysterInventoryTableRow.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterInventoryTableRow.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/v2/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import ImageColored from '$lib/atoms/images/ImageColored.svelte';
-	import ModalButton from '$lib/atoms/v2/modals/ModalButton.svelte';
 	import Timer from '$lib/atoms/timer/Timer.svelte';
 	import Tooltip from '$lib/atoms/tooltips/Tooltip.svelte';
 	import CollapseButton from '$lib/components/v2/buttons/CollapseButton.svelte';
@@ -10,12 +9,6 @@
 	import type { OysterInventoryDataModel } from '$lib/types/oysterComponentType';
 	import { bigNumberToString, epochToDurationString } from '$lib/utils/helpers/conversionHelper';
 	import { getInventoryDurationVariant } from '$lib/utils/v2/helpers/oysterHelpers';
-	import { slide } from 'svelte/transition';
-	import AddFundsToJobModal from '$lib/page-components/v2/oyster/inventory/modals/AddFundsToJobModal.svelte';
-	import AmendRateModal from '$lib/page-components/v2/oyster/inventory/modals/AmendRateModal.svelte';
-	import InventoryJobDetailsModal from '$lib/page-components/v2/oyster/inventory/modals/JobDetailsModal.svelte';
-	import StopJobModal from '$lib/page-components/v2/oyster/inventory/modals/StopJobModal.svelte';
-	import WithdrawFundsFromJobModal from '$lib/page-components/v2/oyster/inventory/modals/WithdrawFundsFromJobModal.svelte';
 	import type { BytesLike } from 'ethers';
 	import { refreshJobStatusForJobId } from '$lib/controllers/httpController';
 	import {
@@ -52,175 +45,84 @@
 	}
 
 	$: ({
-		provider: { name, address },
-		instance,
-		region,
-		rate,
+		provider: { address },
 		id,
 		ip,
 		balance,
 		durationLeft,
-		isCreditJob,
 		endEpochTime, // epoch time in seconds based on duration left,
 		// newRate is being passed to the modal for the amend rate modal and is not used here
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		reviseRate: { newRate = null, rateStatus = '', stopStatus = '' } = {}
 	} = rowData);
-	$: isJobFinished = !(Math.floor(endEpochTime - Date.now() / 1000) > 0);
 	$: isOpen = expandedRows.has(id.toString());
-	$: closeButtonText =
-		stopStatus === '' || stopStatus === 'disabled'
-			? 'Initiate Stop'
-			: stopStatus === 'pending'
-				? 'Cancel Stop'
-				: 'Confirm Stop';
-
-	$: amendRateButtonText =
-		rateStatus === ''
-			? 'Initiate rate amend'
-			: rateStatus === 'pending'
-				? 'Cancel rate amend'
-				: 'Confirm rate amend';
 </script>
 
-<tr class="main-row hover:bg-base-200">
-	<td class={tableCellClasses.rowNormal}>
-		<NameWithAddress {address} {rowIndex}>
-			<svelte:fragment slot="copyIcon">
-				<div class="w-4">
-					<div class="copy-icon cursor-pointer">
-						<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
-					</div>
-				</div>
-			</svelte:fragment>
-		</NameWithAddress>
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		<div class="flex items-center justify-start gap-2">
-			{ip ?? 'N/A'}
-			{#if ip}
-				<button
-					class="cursor-pointer"
-					on:click={() => handleCopyClick(ip, 'IP Address copied to clipboard')}
-				>
+<td class={tableClasses.cell}>
+	<NameWithAddress {address} {rowIndex}>
+		<svelte:fragment slot="copyIcon">
+			<div class="w-4">
+				<div class="copy-icon hidden cursor-pointer group-hover:flex">
 					<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
-				</button>
-			{/if}
+				</div>
+			</div>
+		</svelte:fragment>
+	</NameWithAddress>
+</td>
+<td class={tableClasses.cell}>
+	<div class="flex items-center justify-start gap-2">
+		{ip ?? 'N/A'}
+		{#if ip}
 			<button
-				class="{refreshLoading ? 'animate-spin' : ''} flex items-center"
-				on:click={() => refreshJobStatus(id)}
+				class="cursor-pointer"
+				on:click={() => handleCopyClick(ip, 'IP Address copied to clipboard')}
 			>
-				<img src={staticImages.refreshV2Icon} alt="Refresh Icon" />
+				<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
 			</button>
-		</div>
-	</td>
-
-	<td class={tableCellClasses.rowNormal}>
-		<Tooltip
-			tooltipText="{$oysterTokenMetadataStore.symbol}{bigNumberToString(
-				balance,
-				$oysterTokenMetadataStore.decimal,
-				$oysterTokenMetadataStore.precision
-			)}"
+		{/if}
+		<button
+			class="{refreshLoading ? 'animate-spin' : ''} flex items-center"
+			on:click={() => refreshJobStatus(id)}
 		>
-			{$oysterTokenMetadataStore.symbol}{bigNumberToString(
-				balance,
-				$oysterTokenMetadataStore.decimal
-			)}
-		</Tooltip>
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		<Timer timerId="timer-for-inventory-table-row-{id}" {endEpochTime}>
-			<div slot="active">
-				<Tooltip tooltipText={epochToDurationString(durationLeft)} tooltipDirection="tooltip-left">
-					<div
-						class="mx-auto rounded-full px-[31.5px] py-[10.5px] text-center text-sm text-[#030115]"
-						style="background-color: {getInventoryDurationVariant(durationLeft)}"
-					>
-						{epochToDurationString(durationLeft, true)}
-					</div>
-				</Tooltip>
-			</div>
-			<div slot="inactive">Ended</div>
-		</Timer>
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		<CollapseButton
-			styleClass="mr-6"
-			{isOpen}
-			onclick={() => {
-				toggleRowExpansion(id.toString());
-			}}
-		/>
-	</td>
-</tr>
-<tr class="expanded-row">
-	{#if isOpen}
-		<td colspan="12">
-			<div transition:slide={{ duration: 400 }} class="mb-8 mt-4 flex gap-4 px-8">
-				{#if !isJobFinished}
-					<ModalButton
-						variant="filled"
-						size="small"
-						modalFor="job-add-funds-modal-{id}"
-						disabled={isJobFinished}
-					>
-						Add Funds
-					</ModalButton>
-					<ModalButton
-						variant="outlined"
-						size="small"
-						modalFor="job-stop-modal-{id}"
-						disabled={isJobFinished}
-					>
-						{closeButtonText}
-					</ModalButton>
-					<ModalButton
-						variant="outlined"
-						size="small"
-						modalFor="job-withdraw-fund-modal-{id}"
-						disabled={isJobFinished}
-					>
-						Withdraw
-					</ModalButton>
-					<ModalButton
-						variant="outlined"
-						size="small"
-						modalFor="job-amend-rate-modal-{id}"
-						disabled={isJobFinished}
-					>
-						{amendRateButtonText}
-					</ModalButton>
-				{/if}
-				<ModalButton variant="outlined" size="small" modalFor="job-details-modal-{id}">
-					Details
-				</ModalButton>
-			</div>
-		</td>
-	{/if}
-</tr>
-
-<InventoryJobDetailsModal bind:jobData={rowData} modalFor="job-details-modal-{id}" />
-<AddFundsToJobModal bind:jobData={rowData} modalFor="job-add-funds-modal-{id}" />
-<WithdrawFundsFromJobModal bind:jobData={rowData} modalFor="job-withdraw-fund-modal-{id}" />
-<StopJobModal bind:jobData={rowData} modalFor="job-stop-modal-{id}" />
-<AmendRateModal bind:jobData={rowData} modalFor="job-amend-rate-modal-{id}" />
-
-<style>
-	/* TODO: migrate these classes to tailwind and then refactor the copy to clipboard functionality */
-	.expanded-row {
-		border-bottom: 1px solid #e5e5e5;
-	}
-
-	.expanded-row:last-child {
-		border-bottom: none;
-	}
-
-	/* show icon only on hover on table-row */
-	.main-row:hover .copy-icon {
-		display: flex;
-	}
-	.main-row .copy-icon {
-		display: none;
-	}
-</style>
+			<img src={staticImages.refreshV2Icon} alt="Refresh Icon" />
+		</button>
+	</div>
+</td>
+<td class={tableClasses.cell}>
+	<Tooltip
+		tooltipText="{$oysterTokenMetadataStore.symbol}{bigNumberToString(
+			balance,
+			$oysterTokenMetadataStore.decimal,
+			$oysterTokenMetadataStore.precision
+		)}"
+	>
+		{$oysterTokenMetadataStore.symbol}{bigNumberToString(
+			balance,
+			$oysterTokenMetadataStore.decimal
+		)}
+	</Tooltip>
+</td>
+<td class={tableClasses.cell}>
+	<Timer timerId="timer-for-inventory-table-row-{id}" {endEpochTime}>
+		<div slot="active">
+			<Tooltip tooltipText={epochToDurationString(durationLeft)} tooltipDirection="tooltip-left">
+				<div
+					class="mx-auto rounded-full px-[31.5px] py-[10.5px] text-center text-sm text-[#030115]"
+					style="background-color: {getInventoryDurationVariant(durationLeft)}"
+				>
+					{epochToDurationString(durationLeft, true)}
+				</div>
+			</Tooltip>
+		</div>
+		<div slot="inactive">Ended</div>
+	</Timer>
+</td>
+<td class={tableClasses.cell}>
+	<CollapseButton
+		styleClass="mr-6"
+		{isOpen}
+		onclick={() => {
+			toggleRowExpansion(id.toString());
+		}}
+	/>
+</td>

--- a/src/lib/page-components/v2/oyster/inventory/OysterTableCommon.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterTableCommon.svelte
@@ -5,6 +5,7 @@
 	import LoadingAnimatedPing from '$lib/components/loading/LoadingAnimatedPing.svelte';
 	import { connected } from '$lib/data-stores/walletProviderStore';
 	import type { TableModel } from '$lib/types/componentTypes';
+	import { cn } from '$lib/utils/helpers/commonHelper';
 
 	export let loading = false;
 	export let handleSortData: (id: string) => void;
@@ -25,7 +26,7 @@
 		</div>
 	{:else if noDataFound}
 		<Table {tableHeading} {handleSortData} headingStyleClass="h-[32px]" />
-		<div class="mb-8 {tableClasses.empty}">
+		<div class={cn(tableClasses.empty, 'mb-8')}>
 			{emptyTableMessage}
 		</div>
 	{:else}

--- a/src/lib/page-components/v2/oyster/inventory/OysterTableCommon.svelte
+++ b/src/lib/page-components/v2/oyster/inventory/OysterTableCommon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import Table from '$lib/atoms/v2/table/Table.svelte';
 	import ConnectWalletButton from '$lib/components/header/sub-components/ConnectWalletButton.svelte';
 	import LoadingAnimatedPing from '$lib/components/loading/LoadingAnimatedPing.svelte';
@@ -25,7 +25,7 @@
 		</div>
 	{:else if noDataFound}
 		<Table {tableHeading} {handleSortData} headingStyleClass="h-[32px]" />
-		<div class="mb-8 {tableCellClasses.empty}">
+		<div class="mb-8 {tableClasses.empty}">
 			{emptyTableMessage}
 		</div>
 	{:else}

--- a/src/lib/page-components/v2/oyster/marketplace/OysterMarketplacePage.svelte
+++ b/src/lib/page-components/v2/oyster/marketplace/OysterMarketplacePage.svelte
@@ -13,6 +13,8 @@
 	import { TABLE_ITEMS_PER_PAGE } from '$lib/utils/constants/constants';
 	import { chainIdHasChanged, chainStore } from '$lib/data-stores/chainProviderStore';
 	import { OYSTER_MARKETPLACE_TABLE_HEADER } from '$lib/utils/constants/v2/oysterConstants';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
+	import { cn } from '$lib/utils/helpers/commonHelper';
 
 	let activePage = 1;
 	let sortingMap: Record<string, 'asc' | 'desc'> = {};
@@ -85,13 +87,10 @@
 	>
 		{#if paginatedData?.length}
 			{#each paginatedData as rowData, rowIndex (rowData.id)}
-				<OysterMarketplaceTableRow {rowData} {rowIndex} />
+				<tr class={cn(tableClasses.mainRow, 'group hover:bg-base-200')}>
+					<OysterMarketplaceTableRow {rowData} {rowIndex} />
+				</tr>
 			{/each}
-			<!-- <tr>
-				<td colspan="12">
-					<Pagination {pageCount} {activePage} {handlePageChange} />
-				</td>
-			</tr> -->
 		{/if}
 	</OysterTableCommon>
 	<Pagination {pageCount} {activePage} {handlePageChange} />

--- a/src/lib/page-components/v2/oyster/marketplace/OysterMarketplaceTableRow.svelte
+++ b/src/lib/page-components/v2/oyster/marketplace/OysterMarketplaceTableRow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/atoms/v2/buttons/Button.svelte';
-	import { tableCellClasses } from '$lib/atoms/v2/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import ImageColored from '$lib/atoms/images/ImageColored.svelte';
 	import Tooltip from '$lib/atoms/tooltips/Tooltip.svelte';
 	import { staticImages } from '$lib/components/images/staticImages';
@@ -13,6 +13,7 @@
 	import CreateOrderModal from '$lib/page-components/oyster/inventory/modals/CreateOrderModal.svelte';
 	import { oysterTokenMetadataStore, oysterRateMetadataStore } from '$lib/data-stores/oysterStore';
 	import ModalButton from '$lib/atoms/v2/modals/ModalButton.svelte';
+	import { cn } from '$lib/utils/helpers/commonHelper';
 
 	export let rowData: OysterMarketplaceDataModel;
 	export let rowIndex: number;
@@ -29,79 +30,62 @@
 	$: instanceRate = rateScaled / $oysterRateMetadataStore.oysterRateScalingFactor;
 </script>
 
-<tr class="main-row hover:bg-base-200">
-	<td class={tableCellClasses.rowNormal}>
-		<NameWithAddress {address} {rowIndex}>
-			<svelte:fragment slot="copyIcon">
-				<div class="w-4">
-					<div class="copy-icon cursor-pointer">
-						<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
-					</div>
+<td class={tableClasses.cell}>
+	<NameWithAddress {address} {rowIndex}>
+		<svelte:fragment slot="copyIcon">
+			<div class="w-4">
+				<div class="hidden cursor-pointer group-hover:flex">
+					<ImageColored src={staticImages.CopyGrey} alt="Copy" variant="grey" />
 				</div>
-			</svelte:fragment>
-		</NameWithAddress>
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{instance ?? 'N/A'}
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{region ?? 'N/A'}
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		<Tooltip
-			tooltipText="{$oysterTokenMetadataStore.symbol}{convertRateToPerHourString(
-				instanceRate,
-				$oysterTokenMetadataStore.decimal
-			)}"
+			</div>
+		</svelte:fragment>
+	</NameWithAddress>
+</td>
+<td class={tableClasses.cell}>
+	{instance ?? 'N/A'}
+</td>
+<td class={tableClasses.cell}>
+	{region ?? 'N/A'}
+</td>
+<td class={tableClasses.cell}>
+	<Tooltip
+		tooltipText="{$oysterTokenMetadataStore.symbol}{convertRateToPerHourString(
+			instanceRate,
+			$oysterTokenMetadataStore.decimal
+		)}"
+	>
+		{$oysterTokenMetadataStore.symbol}{convertRateToPerHourString(
+			instanceRate,
+			$oysterTokenMetadataStore.decimal
+		)}
+	</Tooltip>
+</td>
+<td class={tableClasses.cell}>
+	{vcpu ? vcpu : 'N/A'}
+</td>
+<td class={tableClasses.cell}>
+	{memory ? `${memory}${MEMORY_SUFFIX}` : 'N/A'}
+</td>
+<td class={tableClasses.cell}>
+	{arch ? arch : 'N/A'}
+</td>
+<td class={tableClasses.cell}>
+	{#if $connected}
+		<ModalButton
+			variant="tableConvertButton"
+			styleClass="w-fit px-6 mr-4"
+			modalFor="create-order-modal-{rowIndex}">Deploy</ModalButton
 		>
-			{$oysterTokenMetadataStore.symbol}{convertRateToPerHourString(
-				instanceRate,
-				$oysterTokenMetadataStore.decimal
-			)}
-		</Tooltip>
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{vcpu ? vcpu : 'N/A'}
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{memory ? `${memory}${MEMORY_SUFFIX}` : 'N/A'}
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{arch ? arch : 'N/A'}
-	</td>
-	<td class={tableCellClasses.rowNormal}>
-		{#if $connected}
-			<ModalButton
-				variant="tableConvertButton"
-				styleClass="w-fit px-6 mr-4"
-				modalFor="create-order-modal-{rowIndex}">Deploy</ModalButton
-			>
-		{:else}
-			<Button
-				styleClass="w-fit px-6 mr-4"
-				variant="tableConvertButton"
-				onclick={() =>
-					addToast({
-						message: 'Please connect your wallet to deploy.',
-						variant: 'info'
-					})}>Deploy</Button
-			>
-		{/if}
-	</td>
-</tr>
+	{:else}
+		<Button
+			styleClass="w-fit px-6 mr-4"
+			variant="tableConvertButton"
+			onclick={() =>
+				addToast({
+					message: 'Please connect your wallet to deploy.',
+					variant: 'info'
+				})}>Deploy</Button
+		>
+	{/if}
+</td>
 <CreateOrderModal modalFor="create-order-modal-{rowIndex}" preFilledData={rowData} />
-
-<style>
-	/* TODO: migrate these classes to tailwind and then refactor the copy to clipboard functionality */
-	.main-row {
-		margin-left: 20px;
-		border-bottom: 1px solid #e5e5e5;
-	}
-	/* show icon only on hover on table-row */
-	.main-row:hover .copy-icon {
-		display: flex;
-	}
-	.main-row .copy-icon {
-		display: none;
-	}
-</style>

--- a/src/lib/page-components/v2/oyster/sub-components/InstancesTable.svelte
+++ b/src/lib/page-components/v2/oyster/sub-components/InstancesTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import Table from '$lib/atoms/table/Table.svelte';
 	import CollapseButton from '$lib/components/buttons/CollapseButton.svelte';
 	import InputCardWithEndButton from '$lib/components/inputs/InputCardWithEndButton.svelte';
@@ -14,11 +14,6 @@
 	export let tableData: Promise<CPUrlDataModel[]> = Promise.resolve([]);
 	export let isOpen = false;
 	export let validCPUrl = false;
-
-	const styles = {
-		docButton: 'text-primary font-medium',
-		tableCell: tableCellClasses.rowMini
-	};
 </script>
 
 <InputCardWithEndButton styleClass="mt-4" title="Details">
@@ -41,9 +36,9 @@
 					<tbody slot="tableBody">
 						{#each value as row}
 							<tr>
-								<td class={styles.tableCell}>{row.instance}</td>
-								<td class={styles.tableCell}>{row.region}</td>
-								<td class={styles.tableCell}>
+								<td class={tableClasses.cellMini}>{row.instance}</td>
+								<td class={tableClasses.cellMini}>{row.region}</td>
+								<td class={tableClasses.cellMini}>
 									{$oysterTokenMetadataStore.symbol}{convertRateToPerHourString(
 										row.rateScaled / $oysterRateMetadataStore.oysterRateScalingFactor,
 										$oysterTokenMetadataStore.decimal

--- a/src/lib/page-components/v2/oyster/sub-components/PaymentHistoryTable.svelte
+++ b/src/lib/page-components/v2/oyster/sub-components/PaymentHistoryTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tableCellClasses } from '$lib/atoms/componentClasses';
+	import { tableClasses } from '$lib/atoms/v2/componentClasses';
 	import Table from '$lib/atoms/table/Table.svelte';
 	import TxnIcon from '$lib/components/icons/TxnIcon.svelte';
 	import InputCardWithEndButton from '$lib/components/inputs/InputCardWithEndButton.svelte';
@@ -24,14 +24,14 @@
 			<tbody slot="tableBody">
 				{#each tableData as rowData}
 					<tr>
-						<td class={tableCellClasses.rowNormal}>{epochSecToString(rowData.timestamp)}</td>
-						<td class={tableCellClasses.rowNormal}
+						<td class={tableClasses.rowNormal}>{epochSecToString(rowData.timestamp)}</td>
+						<td class={tableClasses.rowNormal}
 							>{$oysterTokenMetadataStore.symbol}{bigNumberToString(
 								rowData.amount,
 								$oysterTokenMetadataStore.decimal
 							)}</td
 						>
-						<td class={tableCellClasses.rowNormal}>
+						<td class={tableClasses.rowNormal}>
 							<div class="flex items-center justify-center gap-2 capitalize">
 								{rowData.transactionStatus}
 								<TxnIcon


### PR DESCRIPTION
# This PR does the following:
- renames `tableCellClasses` -> `tableClasses`
- reduces the table classes to `heading`, `row`, `cell`, `cellMini` and `empty` since it is much more cleaner and intuitive than the 8 classes we had before
- remove the need of explicit `<style></style>` tags in table components to show icons on hover and to add bottom borders
- fixes the issue of each table having a bottom border in its last row
- extracts the expanded row logic+markup of `OysterInventoryTableRow.svelte` into a separate `OysterInventoryExpandedTableRow.svelte` for better readability and maintainability