### PR TITLE
fix gap between second input suffix and balance text bridge

### DIFF
--- a/src/lib/components/inputs/AmountInputWithMaxButton.svelte
+++ b/src/lib/components/inputs/AmountInputWithMaxButton.svelte
@@ -33,7 +33,7 @@
 		{/if}
 		{#if showBalance}
 			<div class="mt-[-10px] flex items-center justify-end gap-2">
-				<div class="flex items-center gap-1">
+				<div class="flex h-8 items-center gap-1">
 					<Text
 						text={maxAmountText}
 						variant="small"

--- a/src/lib/components/inputs/__snapshots__/AmountInputWithMaxButton.dom.spec.ts.snap
+++ b/src/lib/components/inputs/__snapshots__/AmountInputWithMaxButton.dom.spec.ts.snap
@@ -32,7 +32,7 @@ exports[`AmountInputWithMaxButton > render's the component properly 1`] = `
           class="mt-[-10px] flex items-center justify-end gap-2"
         >
           <div
-            class="flex items-center gap-1"
+            class="flex h-8 items-center gap-1"
           >
             <div
               class="text-[#657183] text-sm font-normal"


### PR DESCRIPTION
<img width="627" alt="Screenshot 2024-06-14 at 6 48 20 PM" src="https://github.com/marlinprotocol/interface-v2/assets/58814221/304a65a4-d31e-427d-a046-b105c79ad0ad">
<img width="589" alt="Screenshot 2024-06-14 at 6 48 24 PM" src="https://github.com/marlinprotocol/interface-v2/assets/58814221/24798444-a87e-4ca7-bca7-aa7e6e58bcfd">
