### PR TITLE
add dark mode styles for mpond->pond conversion history cta

### DIFF
--- a/src/lib/page-components/bridge/buttons/MPondConversionCycleButton.svelte
+++ b/src/lib/page-components/bridge/buttons/MPondConversionCycleButton.svelte
@@ -12,7 +12,7 @@
 
 <ModalButton size="tiniest" variant="text" {modalFor}>
 	<div
-		class="flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
+		class="icon-invert flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
 	>
 		<img src={staticImages.conversionCycleIcon} alt="Conversion Cycle Icon" />
 	</div>

--- a/src/lib/page-components/bridge/buttons/MPondConversionHistoryButton.svelte
+++ b/src/lib/page-components/bridge/buttons/MPondConversionHistoryButton.svelte
@@ -14,12 +14,12 @@
 
 <MPondConversionHistoryModal conversions={conversionHistory} {modalFor} />
 {#if !conversionHistory?.length}
-	<div class={cn(classes, 'cursor-not-allowed opacity-50')}>
+	<div class={cn(classes, 'icon-invert cursor-not-allowed opacity-50')}>
 		<img src={staticImages.historyIcon} alt="History Icon" />
 	</div>
 {:else}
 	<ModalButton variant="text" size="tiniest" {modalFor}>
-		<div class={cn(classes, 'hover:bg-[#F0F0F0]')}>
+		<div class={cn(classes, 'icon-invert hover:bg-[#F0F0F0]')}>
 			<img src={staticImages.historyIcon} alt="History Icon" />
 		</div>
 	</ModalButton>

--- a/src/lib/page-components/bridge/history/MPondTableRow.svelte
+++ b/src/lib/page-components/bridge/history/MPondTableRow.svelte
@@ -134,7 +134,7 @@
 					modalFor="mpond-convert-modal-{rowIndex}"
 				>
 					<div
-						class="flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
+						class="icon-invert flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
 					>
 						<img src={staticImages.exchangeIcon} alt="" />
 					</div>
@@ -165,7 +165,7 @@
 				<button
 					slot="tooltipIcon"
 					type="button"
-					class="flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
+					class="icon-invert flex h-[45px] w-[45px] items-center justify-center rounded-full border border-grey-100 hover:bg-[#F0F0F0]"
 					on:click={async () => {
 						await handleCancelConversionRequest(requestEpoch);
 					}}


### PR DESCRIPTION
## before

<img width="1098" alt="Screenshot 2024-07-25 at 3 07 30 PM" src="https://github.com/user-attachments/assets/e2df9811-9b27-41fc-8659-cdccbf90f9d1">

## after

<img width="1089" alt="Screenshot 2024-07-25 at 3 07 41 PM" src="https://github.com/user-attachments/assets/ebd8cafa-5c5d-4d7b-a0ae-383e0e591fb5">
