### PR TITLE
fix kalypso dashboard showing when user has disconnected their wallet

### DIFF
--- a/src/lib/page-components/kalypso/KalypsoDashboard.svelte
+++ b/src/lib/page-components/kalypso/KalypsoDashboard.svelte
@@ -48,8 +48,8 @@
 					</ModalButton>
 				</div>
 			</ContainerCard>
-		{/if}
-		{#if $kalypsoStore.registered}
+			<KalypsoRegisterModal />
+		{:else if $kalypsoStore.registered}
 			<div class="flex flex-col items-center justify-center gap-4">
 				<ContainerCard
 					width={cn({
@@ -78,4 +78,3 @@
 		{/if}
 	</div>
 </div>
-<KalypsoRegisterModal />


### PR DESCRIPTION
## before

![Screenshot 2024-07-25 at 4 13 30 PM](https://github.com/user-attachments/assets/6059b5cb-d4e1-43a7-b4a1-f91d9d121336)

## after 

<img width="1153" alt="Screenshot 2024-07-25 at 4 14 23 PM" src="https://github.com/user-attachments/assets/6ffa8ed5-0753-4188-ae53-6671c14644a1">

